### PR TITLE
Fix macro overlay position handling

### DIFF
--- a/Pages/Macro/MacroOverlay.axaml
+++ b/Pages/Macro/MacroOverlay.axaml
@@ -5,7 +5,7 @@
         TransparencyLevelHint="Transparent"
         Background="Transparent"
         Topmost="True"
-        WindowStartupLocation="CenterScreen"
+        WindowStartupLocation="Manual"
         ExtendClientAreaToDecorationsHint="True"
         ExtendClientAreaChromeHints="NoChrome">
     <Canvas Background="Transparent">

--- a/Pages/Macro/MacroPage.axaml.cs
+++ b/Pages/Macro/MacroPage.axaml.cs
@@ -289,7 +289,7 @@ namespace GTDCompanion.Pages
             // Se mudou a posição pelo dialog, atualize overlay
             if (step.Tipo == "Clique" && overlays.ContainsKey(idx))
             {
-                overlays[idx].Position = new PixelPoint(step.X - (int)(overlays[idx].Width / 2), step.Y - (int)(overlays[idx].Height / 2));
+                overlays[idx].SetCenterPosition(step.X, step.Y);
             }
 
             RefreshStepList();


### PR DESCRIPTION
## Summary
- ensure macro overlays restore saved positions by using WindowStartupLocation `Manual`
- adjust overlay position calculations to account for screen scaling
- add helper to reposition overlays using screen coordinates
- refresh overlay position after step edit

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446344ccbc832a9b4f694b8692038d