### PR TITLE
Fix macro overlay import positioning

### DIFF
--- a/Pages/Macro/MacroOverlay.axaml
+++ b/Pages/Macro/MacroOverlay.axaml
@@ -2,12 +2,13 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="GTDCompanion.Pages.MacroOverlay"
         Width="100" Height="100"
+        ShowInTaskbar="False"
+        SystemDecorations="None"
+        CanResize="False"
         TransparencyLevelHint="Transparent"
         Background="Transparent"
         Topmost="True"
-        WindowStartupLocation="Manual"
-        ExtendClientAreaToDecorationsHint="True"
-        ExtendClientAreaChromeHints="NoChrome">
+        WindowStartupLocation="Manual">
     <Canvas Background="Transparent">
         <Ellipse Name="AlvoCirculo" Width="84" Height="84" Fill="#55FE6A0A" Stroke="#FE6A0A" StrokeThickness="7" Canvas.Left="8" Canvas.Top="8"/>
         <Ellipse Width="24" Height="24" Fill="#CCFFFFFF" Stroke="White" StrokeThickness="2" Canvas.Left="38" Canvas.Top="38"/>

--- a/Pages/Macro/MacroOverlay.axaml.cs
+++ b/Pages/Macro/MacroOverlay.axaml.cs
@@ -31,12 +31,12 @@ namespace GTDCompanion.Pages
 
             EnableTransparency();
 
-            // Se vier x/y absolutos, posicione o centro do overlay em x/y.
+            // Se vier x/y absolutos, posicione o centro do overlay em x/y quando abrir.
             // Caso contrário, centraliza na tela para facilitar o arraste inicial.
             if (x.HasValue && y.HasValue)
             {
                 WindowStartupLocation = WindowStartupLocation.Manual;
-                SetCenterPosition(x.Value, y.Value);
+                Opened += (_, _) => SetCenterPosition(x.Value, y.Value);
             }
             else
             {


### PR DESCRIPTION
## Summary
- correctly position MacroOverlay when loaded from a JSON file
- hide window decorations so only the target is visible

## Testing
- `dotnet build GTDCompanion.sln -c Release` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684466af8f94832aa63959612b9cccfd