### PR TITLE
Fix macro overlay scaling

### DIFF
--- a/Pages/Macro/MacroOverlay.axaml.cs
+++ b/Pages/Macro/MacroOverlay.axaml.cs
@@ -46,8 +46,8 @@ namespace GTDCompanion.Pages
 
         public void SetCenterPosition(int screenX, int screenY)
         {
-            int px = (int)(screenX / Scaling - Width / 2);
-            int py = (int)(screenY / Scaling - Height / 2);
+            int px = (int)(screenX - (Width * Scaling) / 2);
+            int py = (int)(screenY - (Height * Scaling) / 2);
             Position = new PixelPoint(px, py);
         }
 


### PR DESCRIPTION
## Summary
- correctly account for window scaling in `MacroOverlay.SetCenterPosition`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446981d940832a833e5570d2589c51