### PR TITLE
Fix macro overlay visibility and global F8 hotkey

### DIFF
--- a/Helpers/GlobalHotkey.cs
+++ b/Helpers/GlobalHotkey.cs
@@ -37,10 +37,8 @@ namespace GTDCompanion.Helpers
             if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
             {
                 var info = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
-                bool ctrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
-                bool alt = (GetKeyState(VK_MENU) & 0x8000) != 0;
-                bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
-                if (ctrl && alt && shift && info.vkCode == VK_F8)
+                // Aciona a macro com F8 sem necessidade de modificadores
+                if (info.vkCode == VK_F8)
                 {
                     _callback();
                     return (IntPtr)1; // consume
@@ -51,9 +49,6 @@ namespace GTDCompanion.Helpers
 
         private const int WH_KEYBOARD_LL = 13;
         private const int VK_F8 = 0x77;
-        private const int VK_CONTROL = 0x11;
-        private const int VK_MENU = 0x12; // Alt
-        private const int VK_SHIFT = 0x10;
 
         [StructLayout(LayoutKind.Sequential)]
         private struct KBDLLHOOKSTRUCT
@@ -76,8 +71,6 @@ namespace GTDCompanion.Helpers
         [DllImport("user32.dll")]
         private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
 
-        [DllImport("user32.dll")]
-        private static extern short GetKeyState(int nVirtKey);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
         private static extern IntPtr GetModuleHandle(string? lpModuleName);

--- a/Pages/Macro/MacroOverlay.axaml.cs
+++ b/Pages/Macro/MacroOverlay.axaml.cs
@@ -29,7 +29,9 @@ namespace GTDCompanion.Pages
             PointerReleased += OnPointerReleased;
             PointerMoved += OnPointerMoved;
 
-            EnableTransparency();
+            // Habilita transparência e esconde do ALT+TAB somente após a janela
+            // estar aberta, garantindo que o handle já exista.
+            Opened += (_, _) => EnableTransparency();
 
             // Se vier x/y absolutos, posicione o centro do overlay em x/y quando abrir.
             // Caso contrário, centraliza na tela para facilitar o arraste inicial.


### PR DESCRIPTION
## Summary
- hide macro overlay from ALT+TAB when window opens
- allow F8 key alone to toggle macros globally

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447a639b1c832a9913f1cf1f8f1c05