### PR TITLE
Add macro reset option

### DIFF
--- a/Pages/Macro/MacroPage.axaml
+++ b/Pages/Macro/MacroPage.axaml
@@ -33,6 +33,8 @@
             <Button Name="SaveMacroButton" Content="Salvar Macro"/>
             <Button Name="LoadMacroButton" Content="Importar Macro"/>
             <Button Name="ExecuteMacroButton" Content="Executar Macro"/>
+            <Button Name="ResetMacroButton" Content="Resetar Macros"/>
         </StackPanel>
+        <TextBlock Text="Pressione F8 para executar a macro" Foreground="#CCC" Margin="0,4,0,0"/>
     </StackPanel>
 </UserControl>

--- a/Pages/Macro/MacroPage.axaml.cs
+++ b/Pages/Macro/MacroPage.axaml.cs
@@ -29,6 +29,7 @@ namespace GTDCompanion.Pages
             SaveMacroButton.Click += SaveMacro;
             LoadMacroButton.Click += LoadMacro;
             ExecuteMacroButton.Click += ExecuteMacro;
+            ResetMacroButton.Click += ResetMacros;
 
             StepListBox.DoubleTapped += StepListBox_DoubleTapped;
 
@@ -256,6 +257,15 @@ namespace GTDCompanion.Pages
                 ov.SetClickThrough(false);
             isRunning = false;
             ExecuteMacroButton.Content = "Executar Macro";
+        }
+
+        private void ResetMacros(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            foreach (var ov in overlays.Values)
+                ov.Close();
+            overlays.Clear();
+            macroSteps.Clear();
+            RefreshStepList();
         }
 
         private void UpdateOverlayPosition(int idx, int x, int y)


### PR DESCRIPTION
## Summary
- update macro page layout with a reset button
- show F8 shortcut hint under the macro buttons
- handle ResetMacroButton click and clear overlays

## Testing
- `dotnet build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447f43c6b8832ab30f1ded692056d9