### PR TITLE
Implement Sticker Notes overlays

### DIFF
--- a/GTDConfigHelper.cs
+++ b/GTDConfigHelper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System;
 using Avalonia.Media;
 using System.Globalization;
+using GTDCompanion.Pages;
 
 namespace GTDCompanion
 {
@@ -139,6 +140,28 @@ namespace GTDCompanion
             var data = File.Exists(path) ? parser.ReadFile(path) : new IniData();
             data["Perfil"]["GtdId"] = gtdId ?? "";
             parser.WriteFile(path, data);
+        }
+
+        // ---- Sticker Notes ----
+        public static StickerNoteConfig LoadStickerNoteConfig(int index)
+        {
+            string section = $"StickerNote{index}";
+            return new StickerNoteConfig
+            {
+                Text = GetString(section, "Text", ""),
+                Opacity = GetDouble(section, "Opacity", 0.9),
+                PosX = GetInt(section, "PosX", -1),
+                PosY = GetInt(section, "PosY", -1)
+            };
+        }
+
+        public static void SaveStickerNoteConfig(int index, StickerNoteConfig config)
+        {
+            string section = $"StickerNote{index}";
+            Set(section, "Text", config.Text);
+            Set(section, "Opacity", config.Opacity.ToString(CultureInfo.InvariantCulture));
+            Set(section, "PosX", config.PosX.ToString());
+            Set(section, "PosY", config.PosY.ToString());
         }
     }
 }

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -82,6 +82,7 @@
                 <MenuItem Header="Benchmark" Click="BenchmarkOverlayPage_Click"/>
                 <MenuItem Header="Mira Overlay" Click="MenuMira_Click"/>
                 <MenuItem Header="Tradução IA Overlay" Click="TranslatorOverlay_Click"/>
+                <MenuItem Header="Sticker Notes" Click="StickerNotesPage_Click"/>
                 <MenuItem Header="Macro Experience" Click="MacroPage_Click"/>
             </MenuItem>
             <MenuItem Header="Links">

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -106,6 +106,11 @@ namespace GTDCompanion
             MainContent.Content = new TranslatorPage();
         }
 
+        private void StickerNotesPage_Click(object? sender, RoutedEventArgs e)
+        {
+            MainContent.Content = new StickerNotesPage();
+        }
+
         private void MacroPage_Click(object? sender, RoutedEventArgs e)
         {
             MainContent.Content = new MacroPage();

--- a/Pages/StickerNotes/StickerNoteWindow.axaml
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml
@@ -1,0 +1,21 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="GTDCompanion.Pages.StickerNoteWindow"
+        Width="250" Height="200"
+        CanResize="False"
+        Topmost="True"
+        ShowInTaskbar="False"
+        Background="Transparent"
+        Opacity="0.9"
+        SystemDecorations="None">
+  <Border CornerRadius="12" Background="#DD23272A" Padding="10">
+    <StackPanel Spacing="6">
+      <DockPanel Name="CustomTitleBar" Height="30" HorizontalAlignment="Stretch">
+        <TextBlock Text="Sticker Note" Foreground="#FF9800" FontSize="14" Margin="8,0,0,0" VerticalAlignment="Center" DockPanel.Dock="Left"/>
+        <Button Name="CloseButton" Content="X" Width="24" Height="24" Background="#600" Foreground="White" Margin="2,0,8,0" DockPanel.Dock="Right"/>
+      </DockPanel>
+      <TextBox Name="NoteTextBox" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="100" Background="#333" Foreground="White"/>
+      <Slider Name="TransparencySlider" Minimum="0.3" Maximum="1" Value="0.9"/>
+    </StackPanel>
+  </Border>
+</Window>

--- a/Pages/StickerNotes/StickerNoteWindow.axaml.cs
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml.cs
@@ -1,0 +1,94 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using System.Globalization;
+
+namespace GTDCompanion.Pages
+{
+    public partial class StickerNoteWindow : Window
+    {
+        private bool dragging;
+        private PixelPoint dragOffset;
+        private readonly int index;
+
+        public StickerNoteWindow(int index)
+        {
+            this.index = index;
+            InitializeComponent();
+
+            var cfg = GTDConfigHelper.LoadStickerNoteConfig(index);
+            NoteTextBox.Text = cfg.Text;
+            Opacity = cfg.Opacity;
+            TransparencySlider.Value = cfg.Opacity;
+            if (cfg.PosX >= 0 && cfg.PosY >= 0)
+                Position = new PixelPoint(cfg.PosX, cfg.PosY);
+
+            TransparencySlider.PropertyChanged += (_, e) =>
+            {
+                if (e.Property.Name == "Value")
+                {
+                    var v = System.Math.Round(TransparencySlider.Value, 2);
+                    Opacity = v;
+                    SaveConfig();
+                }
+            };
+
+            NoteTextBox.GetObservable(TextBox.TextProperty).Subscribe(_ => SaveConfig());
+
+            PointerPressed += OnPointerPressed;
+            PointerReleased += OnPointerReleased;
+            PointerMoved += OnPointerMoved;
+
+            if (this.FindControl<Button>("CloseButton") is Button closeBtn)
+                closeBtn.Click += (_, __) => this.Close();
+        }
+
+        private void SaveConfig()
+        {
+            var cfg = new StickerNoteConfig
+            {
+                Text = NoteTextBox.Text ?? string.Empty,
+                Opacity = Opacity,
+                PosX = this.Position.X,
+                PosY = this.Position.Y
+            };
+            GTDConfigHelper.SaveStickerNoteConfig(index, cfg);
+        }
+
+        private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+            {
+                dragging = true;
+                var screenPos = this.PointToScreen(e.GetPosition(this));
+                dragOffset = new PixelPoint(screenPos.X - Position.X, screenPos.Y - Position.Y);
+                e.Pointer.Capture(this);
+            }
+        }
+
+        private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            dragging = false;
+            e.Pointer.Capture(null);
+            SaveConfig();
+        }
+
+        private void OnPointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (dragging)
+            {
+                var screenPos = this.PointToScreen(e.GetPosition(this));
+                Position = new PixelPoint(screenPos.X - dragOffset.X, screenPos.Y - dragOffset.Y);
+            }
+        }
+    }
+
+    public class StickerNoteConfig
+    {
+        public string Text { get; set; } = string.Empty;
+        public double Opacity { get; set; } = 0.9;
+        public int PosX { get; set; } = -1;
+        public int PosY { get; set; } = -1;
+    }
+}

--- a/Pages/StickerNotes/StickerNotesPage.axaml
+++ b/Pages/StickerNotes/StickerNotesPage.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GTDCompanion.Pages.StickerNotesPage">
+  <Border Background="#222" CornerRadius="12" Padding="20">
+    <StackPanel Spacing="12">
+      <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+        <TextBlock Text="Sticker Notes Overlay" FontSize="24" Foreground="#FE6A0A" FontWeight="Bold" HorizontalAlignment="Center"/>
+      </StackPanel>
+      <TextBlock Text="Crie notas rápidas que ficam sobre todas as janelas." Foreground="#CCC" HorizontalAlignment="Center"/>
+      <WrapPanel HorizontalAlignment="Center" Spacing="8">
+        <Button Name="Note1Button" Content="Nota 1" Width="80" Height="30"/>
+        <Button Name="Note2Button" Content="Nota 2" Width="80" Height="30"/>
+        <Button Name="Note3Button" Content="Nota 3" Width="80" Height="30"/>
+        <Button Name="Note4Button" Content="Nota 4" Width="80" Height="30"/>
+        <Button Name="Note5Button" Content="Nota 5" Width="80" Height="30"/>
+      </WrapPanel>
+    </StackPanel>
+  </Border>
+</UserControl>

--- a/Pages/StickerNotes/StickerNotesPage.axaml.cs
+++ b/Pages/StickerNotes/StickerNotesPage.axaml.cs
@@ -1,0 +1,36 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace GTDCompanion.Pages
+{
+    public partial class StickerNotesPage : UserControl
+    {
+        private readonly StickerNoteWindow?[] windows = new StickerNoteWindow?[5];
+
+        public StickerNotesPage()
+        {
+            InitializeComponent();
+            Note1Button.Click += (_, __) => ToggleWindow(0);
+            Note2Button.Click += (_, __) => ToggleWindow(1);
+            Note3Button.Click += (_, __) => ToggleWindow(2);
+            Note4Button.Click += (_, __) => ToggleWindow(3);
+            Note5Button.Click += (_, __) => ToggleWindow(4);
+        }
+
+        private void ToggleWindow(int idx)
+        {
+            if (windows[idx] == null || !windows[idx]!.IsVisible)
+            {
+                var win = new StickerNoteWindow(idx + 1);
+                windows[idx] = win;
+                win.Closed += (_, __) => windows[idx] = null;
+                win.Show();
+            }
+            else
+            {
+                windows[idx]!.Close();
+                windows[idx] = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Sticker Notes overlays with persistent text, opacity and position
- hook new Sticker Notes page into main menu
- store sticker note data using GTDConfigHelper

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449799291c832a888e45befc74c353