### PR TITLE
Implement sticker note toggle logic

### DIFF
--- a/Pages/StickerNotes/StickerNoteWindow.axaml
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml
@@ -12,7 +12,6 @@
     <StackPanel Spacing="6">
       <DockPanel Name="CustomTitleBar" Height="30" HorizontalAlignment="Stretch">
         <TextBlock Text="Sticker Note" Foreground="#FF9800" FontSize="14" Margin="8,0,0,0" VerticalAlignment="Center" DockPanel.Dock="Left"/>
-        <Button Name="CloseButton" Content="X" Width="24" Height="24" Background="#600" Foreground="White" Margin="2,0,8,0" DockPanel.Dock="Right"/>
       </DockPanel>
       <TextBox Name="NoteTextBox" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="100" Background="#333" Foreground="White"/>
       <Slider Name="TransparencySlider" Minimum="0.3" Maximum="1" Value="0.9"/>

--- a/Pages/StickerNotes/StickerNoteWindow.axaml.cs
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml.cs
@@ -11,6 +11,8 @@ namespace GTDCompanion.Pages
         private bool dragging;
         private PixelPoint dragOffset;
         private readonly int index;
+        private bool _collapsed = false;
+        private double _originalHeight = 0;
 
         public StickerNoteWindow(int index)
         {
@@ -39,9 +41,9 @@ namespace GTDCompanion.Pages
             PointerPressed += OnPointerPressed;
             PointerReleased += OnPointerReleased;
             PointerMoved += OnPointerMoved;
+            this.PointerPressed += OnPointerPressedTitleBar;
 
-            if (this.FindControl<Button>("CloseButton") is Button closeBtn)
-                closeBtn.Click += (_, __) => this.Close();
+            _originalHeight = Height;
         }
 
         private void SaveConfig()
@@ -80,6 +82,34 @@ namespace GTDCompanion.Pages
             {
                 var screenPos = this.PointToScreen(e.GetPosition(this));
                 Position = new PixelPoint(screenPos.X - dragOffset.X, screenPos.Y - dragOffset.Y);
+            }
+        }
+
+        private void OnPointerPressedTitleBar(object? sender, PointerPressedEventArgs e)
+        {
+            if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+                return;
+
+            if (e.ClickCount == 2)
+            {
+                var pos = e.GetPosition(this);
+                if (pos.Y <= 30)
+                    ToggleCollapse();
+            }
+        }
+
+        private void ToggleCollapse()
+        {
+            if (!_collapsed)
+            {
+                _originalHeight = this.Height;
+                this.Height = 50;
+                _collapsed = true;
+            }
+            else
+            {
+                this.Height = _originalHeight;
+                _collapsed = false;
             }
         }
     }

--- a/Pages/StickerNotes/StickerNotesPage.axaml.cs
+++ b/Pages/StickerNotes/StickerNotesPage.axaml.cs
@@ -1,15 +1,23 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Media;
 
 namespace GTDCompanion.Pages
 {
     public partial class StickerNotesPage : UserControl
     {
         private readonly StickerNoteWindow?[] windows = new StickerNoteWindow?[5];
+        private readonly IBrush?[] defaultBackgrounds = new IBrush?[5];
+        private readonly IBrush openBrush = new SolidColorBrush(Color.Parse("#FE6A0A"));
 
         public StickerNotesPage()
         {
             InitializeComponent();
+            defaultBackgrounds[0] = Note1Button.Background;
+            defaultBackgrounds[1] = Note2Button.Background;
+            defaultBackgrounds[2] = Note3Button.Background;
+            defaultBackgrounds[3] = Note4Button.Background;
+            defaultBackgrounds[4] = Note5Button.Background;
             Note1Button.Click += (_, __) => ToggleWindow(0);
             Note2Button.Click += (_, __) => ToggleWindow(1);
             Note3Button.Click += (_, __) => ToggleWindow(2);
@@ -17,19 +25,35 @@ namespace GTDCompanion.Pages
             Note5Button.Click += (_, __) => ToggleWindow(4);
         }
 
+        private Button GetButton(int idx) => idx switch
+        {
+            0 => Note1Button,
+            1 => Note2Button,
+            2 => Note3Button,
+            3 => Note4Button,
+            _ => Note5Button,
+        };
+
         private void ToggleWindow(int idx)
         {
+            var btn = GetButton(idx);
             if (windows[idx] == null || !windows[idx]!.IsVisible)
             {
                 var win = new StickerNoteWindow(idx + 1);
                 windows[idx] = win;
-                win.Closed += (_, __) => windows[idx] = null;
+                win.Closed += (_, __) =>
+                {
+                    windows[idx] = null;
+                    btn.Background = defaultBackgrounds[idx];
+                };
                 win.Show();
+                btn.Background = openBrush;
             }
             else
             {
                 windows[idx]!.Close();
                 windows[idx] = null;
+                btn.Background = defaultBackgrounds[idx];
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove close button from sticker notes
- allow double-click on title bar to minimize/restore
- highlight buttons while a note is open

## Testing
- `dotnet build GTDCompanion.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449b55b808832a9f8dfe9be67d100c