### PR TITLE
Improve sticker note toggle interaction

### DIFF
--- a/Pages/StickerNotes/StickerNoteWindow.axaml
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml
@@ -10,7 +10,7 @@
         SystemDecorations="None">
   <Border CornerRadius="12" Background="#DD23272A" Padding="10">
     <StackPanel Spacing="6">
-      <DockPanel Name="CustomTitleBar" Height="30" HorizontalAlignment="Stretch">
+      <DockPanel Name="CustomTitleBar" Height="30" HorizontalAlignment="Stretch" PointerPressed="CustomTitleBar_PointerPressed">
         <TextBlock Text="Sticker Note" Foreground="#FF9800" FontSize="14" Margin="8,0,0,0" VerticalAlignment="Center" DockPanel.Dock="Left"/>
       </DockPanel>
       <TextBox Name="NoteTextBox" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="100" Background="#333" Foreground="White"/>

--- a/Pages/StickerNotes/StickerNoteWindow.axaml.cs
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml.cs
@@ -41,7 +41,10 @@ namespace GTDCompanion.Pages
             PointerPressed += OnPointerPressed;
             PointerReleased += OnPointerReleased;
             PointerMoved += OnPointerMoved;
-            this.PointerPressed += OnPointerPressedTitleBar;
+
+            var titleBar = this.FindControl<DockPanel>("CustomTitleBar");
+            if (titleBar is not null)
+                titleBar.PointerPressed += CustomTitleBar_PointerPressed;
 
             _originalHeight = Height;
         }
@@ -85,7 +88,7 @@ namespace GTDCompanion.Pages
             }
         }
 
-        private void OnPointerPressedTitleBar(object? sender, PointerPressedEventArgs e)
+        private void CustomTitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
         {
             if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
                 return;


### PR DESCRIPTION
## Summary
- handle double-click collapse using only the note window's custom title bar

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449ede3d54832ab37f0aa1dbddcb31