### PR TITLE
Enable resizing for sticker note window

### DIFF
--- a/Pages/StickerNotes/StickerNoteWindow.axaml
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml
@@ -2,19 +2,22 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="GTDCompanion.Pages.StickerNoteWindow"
         Width="250" Height="200"
-        CanResize="False"
+        CanResize="True"
         Topmost="True"
         ShowInTaskbar="False"
         Background="Transparent"
         Opacity="0.9"
         SystemDecorations="None">
-  <Border CornerRadius="12" Background="#DD23272A" Padding="10">
-    <StackPanel Spacing="6">
-      <DockPanel Name="CustomTitleBar" Height="30" HorizontalAlignment="Stretch" PointerPressed="CustomTitleBar_PointerPressed">
-        <TextBlock Text="Sticker Note" Foreground="#FF9800" FontSize="14" Margin="8,0,0,0" VerticalAlignment="Center" DockPanel.Dock="Left"/>
-      </DockPanel>
-      <TextBox Name="NoteTextBox" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="100" Background="#333" Foreground="White"/>
-      <Slider Name="TransparencySlider" Minimum="0.3" Maximum="1" Value="0.9"/>
-    </StackPanel>
-  </Border>
+  <Grid>
+    <Border CornerRadius="12" Background="#DD23272A" Padding="10">
+      <StackPanel Spacing="6">
+        <DockPanel Name="CustomTitleBar" Height="30" HorizontalAlignment="Stretch" PointerPressed="CustomTitleBar_PointerPressed">
+          <TextBlock Text="Sticker Note" Foreground="#FF9800" FontSize="14" Margin="8,0,0,0" VerticalAlignment="Center" DockPanel.Dock="Left"/>
+        </DockPanel>
+        <TextBox Name="NoteTextBox" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="100" Background="#333" Foreground="White"/>
+        <Slider Name="TransparencySlider" Minimum="0.3" Maximum="1" Value="0.9"/>
+      </StackPanel>
+    </Border>
+    <Thumb Name="ResizeThumb" Width="14" Height="14" HorizontalAlignment="Right" VerticalAlignment="Bottom" Cursor="SizeNWSE"/>
+  </Grid>
 </Window>

--- a/Pages/StickerNotes/StickerNoteWindow.axaml.cs
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using System.Globalization;
@@ -45,6 +46,10 @@ namespace GTDCompanion.Pages
             var titleBar = this.FindControl<DockPanel>("CustomTitleBar");
             if (titleBar is not null)
                 titleBar.PointerPressed += CustomTitleBar_PointerPressed;
+
+            var resizeThumb = this.FindControl<Thumb>("ResizeThumb");
+            if (resizeThumb is not null)
+                resizeThumb.DragDelta += ResizeThumb_DragDelta;
 
             _originalHeight = Height;
         }
@@ -114,6 +119,12 @@ namespace GTDCompanion.Pages
                 this.Height = _originalHeight;
                 _collapsed = false;
             }
+        }
+
+        private void ResizeThumb_DragDelta(object? sender, VectorEventArgs e)
+        {
+            Width = System.Math.Max(Width + e.Vector.X, 100);
+            Height = System.Math.Max(Height + e.Vector.Y, 50);
         }
     }
 


### PR DESCRIPTION
## Summary
- allow `StickerNoteWindow` to be resized
- add a resize thumb to the window template
- handle thumb dragging to update window size

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a0a10e1c832ab08679a67ceaf79e