### PR TITLE
Fix sticker note compile error

### DIFF
--- a/Pages/StickerNotes/StickerNoteWindow.axaml.cs
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml.cs
@@ -4,6 +4,8 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using System.Globalization;
+using System;
+using System.Reactive.Linq;
 
 namespace GTDCompanion.Pages
 {


### PR DESCRIPTION
## Summary
- fix lambda subscribe compile error by adding missing usings

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a57c0360832abbd9f44d67f1a07f