### PR TITLE
Handle double click collapse for StickerNoteWindow

### DIFF
--- a/Pages/StickerNotes/StickerNoteWindow.axaml.cs
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml.cs
@@ -43,9 +43,10 @@ namespace GTDCompanion.Pages
             PointerReleased += OnPointerReleased;
             PointerMoved += OnPointerMoved;
 
-            var titleBar = this.FindControl<DockPanel>("CustomTitleBar");
-            if (titleBar is not null)
-                titleBar.PointerPressed += CustomTitleBar_PointerPressed;
+            // Handle double click on the title bar to collapse/expand the overlay
+            // Using the window's PointerPressed ensures the event fires even if
+            // the DockPanel has no background set.
+            this.PointerPressed += CustomTitleBar_PointerPressed;
 
             _originalHeight = Height;
         }


### PR DESCRIPTION
## Summary
- hook window pointer events for double-click detection on sticker notes
- keep collapse logic so the overlay shows only the title bar

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a9fc69d4832a8bc77dc5928cc667