### PR TITLE
Update StickerNote title dynamically

### DIFF
--- a/Pages/StickerNotes/StickerNoteWindow.axaml.cs
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml.cs
@@ -22,6 +22,7 @@ namespace GTDCompanion.Pages
 
             var cfg = GTDConfigHelper.LoadStickerNoteConfig(index);
             NoteTextBox.Text = cfg.Text;
+            UpdateWindowTitle(cfg.Text);
             Opacity = cfg.Opacity;
             TransparencySlider.Value = cfg.Opacity;
             if (cfg.PosX >= 0 && cfg.PosY >= 0)
@@ -37,7 +38,11 @@ namespace GTDCompanion.Pages
                 }
             };
 
-            NoteTextBox.GetObservable(TextBox.TextProperty).Subscribe(_ => SaveConfig());
+            NoteTextBox.GetObservable(TextBox.TextProperty).Subscribe(text =>
+            {
+                SaveConfig();
+                UpdateWindowTitle(text ?? string.Empty);
+            });
 
             PointerPressed += OnPointerPressed;
             PointerReleased += OnPointerReleased;
@@ -88,6 +93,14 @@ namespace GTDCompanion.Pages
                 var screenPos = this.PointToScreen(e.GetPosition(this));
                 Position = new PixelPoint(screenPos.X - dragOffset.X, screenPos.Y - dragOffset.Y);
             }
+        }
+
+        private void UpdateWindowTitle(string text)
+        {
+            var sanitized = text.Replace("\n", " ").Replace("\r", " ");
+            if (sanitized.Length > 20)
+                sanitized = sanitized.Substring(0, 20);
+            Title = sanitized;
         }
 
         private void CustomTitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)


### PR DESCRIPTION
## Summary
- update StickerNoteWindow to set title from the note text
- update title whenever the text changes

## Testing
- `dotnet build -v minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844abd98290832a94fba3fd4c0c37bd