### PR TITLE
Add keyboard/mouse stats and tray behavior

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -1,7 +1,9 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Controls;
 using GTDCompanion.Pages;
+using GTDCompanion.Helpers;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text;
@@ -20,7 +22,7 @@ namespace GTDCompanion
         {
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                desktop.ShutdownMode = Avalonia.Controls.ShutdownMode.OnMainWindowClose;
+                desktop.ShutdownMode = Avalonia.Controls.ShutdownMode.OnExplicitShutdown;
                 desktop.MainWindow = new MainWindow();
                 desktop.MainWindow.Closed += (_, __) =>
                 {
@@ -30,6 +32,32 @@ namespace GTDCompanion
                             w.Close();
                     }
                 };
+
+                StatsTracker.Load();
+                StatsTracker.Start();
+
+                var tray = new TrayIcon
+                {
+                    Icon = new WindowIcon("Assets/icon.ico"),
+                    ToolTipText = "GTD Companion"
+                };
+                var menu = new NativeMenu();
+                var exitItem = new NativeMenuItem("Encerrar");
+                exitItem.Click += (_, __) =>
+                {
+                    StatsTracker.Stop();
+                    desktop.Shutdown();
+                };
+                menu.Items.Add(exitItem);
+                tray.Menu = menu;
+                tray.Clicked += (_, __) =>
+                {
+                    desktop.MainWindow?.Show();
+                    if (desktop.MainWindow != null)
+                        desktop.MainWindow.WindowState = WindowState.Normal;
+                };
+                tray.IsVisible = true;
+
                 desktop.MainWindow.Show();
             }
 

--- a/Helpers/StatsTracker.cs
+++ b/Helpers/StatsTracker.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace GTDCompanion.Helpers
+{
+    public class KeyboardMouseStats
+    {
+        public int KeyPresses { get; set; }
+        public int LeftClicks { get; set; }
+        public int RightClicks { get; set; }
+        public int ScrollTicks { get; set; }
+        public Dictionary<int, int> KeyCounts { get; } = new();
+    }
+
+    public static class StatsTracker
+    {
+        public static KeyboardMouseStats Stats { get; } = new();
+
+        private static IntPtr _keyboardHook;
+        private static IntPtr _mouseHook;
+        private static LowLevelProc? _keyboardProc;
+        private static LowLevelProc? _mouseProc;
+
+        public static event Action? StatsUpdated;
+
+        public static void Load()
+        {
+            Stats.KeyPresses = GTDConfigHelper.GetInt("Stats", "KeyPresses", 0);
+            Stats.LeftClicks = GTDConfigHelper.GetInt("Stats", "LeftClicks", 0);
+            Stats.RightClicks = GTDConfigHelper.GetInt("Stats", "RightClicks", 0);
+            Stats.ScrollTicks = GTDConfigHelper.GetInt("Stats", "ScrollTicks", 0);
+            var json = GTDConfigHelper.Get("Stats", "KeyCounts", "{}");
+            try
+            {
+                var dict = JsonSerializer.Deserialize<Dictionary<int, int>>(json);
+                if (dict != null)
+                {
+                    foreach (var kv in dict)
+                        Stats.KeyCounts[kv.Key] = kv.Value;
+                }
+            }
+            catch { }
+        }
+
+        private static void Save()
+        {
+            GTDConfigHelper.Set("Stats", "KeyPresses", Stats.KeyPresses.ToString());
+            GTDConfigHelper.Set("Stats", "LeftClicks", Stats.LeftClicks.ToString());
+            GTDConfigHelper.Set("Stats", "RightClicks", Stats.RightClicks.ToString());
+            GTDConfigHelper.Set("Stats", "ScrollTicks", Stats.ScrollTicks.ToString());
+            var json = JsonSerializer.Serialize(Stats.KeyCounts);
+            GTDConfigHelper.Set("Stats", "KeyCounts", json);
+        }
+
+        public static void Start()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+            if (_keyboardHook != IntPtr.Zero)
+                return;
+            _keyboardProc = KeyboardHookCallback;
+            _mouseProc = MouseHookCallback;
+            _keyboardHook = SetWindowsHookEx(WH_KEYBOARD_LL, _keyboardProc, GetModuleHandle(null), 0);
+            _mouseHook = SetWindowsHookEx(WH_MOUSE_LL, _mouseProc, GetModuleHandle(null), 0);
+        }
+
+        public static void Stop()
+        {
+            if (!OperatingSystem.IsWindows())
+                return;
+            if (_keyboardHook != IntPtr.Zero)
+            {
+                UnhookWindowsHookEx(_keyboardHook);
+                _keyboardHook = IntPtr.Zero;
+            }
+            if (_mouseHook != IntPtr.Zero)
+            {
+                UnhookWindowsHookEx(_mouseHook);
+                _mouseHook = IntPtr.Zero;
+            }
+        }
+
+        private static IntPtr KeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+        {
+            const int WM_KEYDOWN = 0x0100;
+            if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
+            {
+                var info = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
+                Stats.KeyPresses++;
+                if (!Stats.KeyCounts.ContainsKey(info.vkCode))
+                    Stats.KeyCounts[info.vkCode] = 0;
+                Stats.KeyCounts[info.vkCode]++;
+                Save();
+                StatsUpdated?.Invoke();
+            }
+            return CallNextHookEx(_keyboardHook, nCode, wParam, lParam);
+        }
+
+        private static IntPtr MouseHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+        {
+            if (nCode >= 0)
+            {
+                switch ((int)wParam)
+                {
+                    case WM_LBUTTONDOWN:
+                        Stats.LeftClicks++;
+                        break;
+                    case WM_RBUTTONDOWN:
+                        Stats.RightClicks++;
+                        break;
+                    case WM_MOUSEWHEEL:
+                        var m = Marshal.PtrToStructure<MSLLHOOKSTRUCT>(lParam);
+                        int delta = (short)((m.mouseData >> 16) & 0xffff);
+                        Stats.ScrollTicks += delta / 120;
+                        break;
+                }
+                Save();
+                StatsUpdated?.Invoke();
+            }
+            return CallNextHookEx(_mouseHook, nCode, wParam, lParam);
+        }
+
+        private delegate IntPtr LowLevelProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+        private const int WH_KEYBOARD_LL = 13;
+        private const int WH_MOUSE_LL = 14;
+
+        private const int WM_LBUTTONDOWN = 0x0201;
+        private const int WM_RBUTTONDOWN = 0x0204;
+        private const int WM_MOUSEWHEEL = 0x020A;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct POINT { public int x; public int y; }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct KBDLLHOOKSTRUCT
+        {
+            public int vkCode;
+            public int scanCode;
+            public int flags;
+            public int time;
+            public IntPtr dwExtraInfo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MSLLHOOKSTRUCT
+        {
+            public POINT pt;
+            public int mouseData;
+            public int flags;
+            public int time;
+            public IntPtr dwExtraInfo;
+        }
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SetWindowsHookEx(int idHook, LowLevelProc lpfn, IntPtr hMod, uint threadId);
+
+        [DllImport("user32.dll")]
+        private static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern IntPtr GetModuleHandle(string? lpModuleName);
+    }
+}

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -90,6 +90,9 @@
                 <MenuItem Header="A GTD" Click="MenuSobre_Click"/>
                 <MenuItem Header="Suporte" Click="MenuSuporte_Click"/>
             </MenuItem>
+            <MenuItem Header="Wtf?!">
+                <MenuItem Header="Estatísticas Teclado/Mouse" Click="KeyboardMouseStatsPage_Click"/>
+            </MenuItem>
         </Menu>
         <!-- Conteúdo central dinâmico -->
         <ContentControl x:Name="MainContent" Margin="0,1,0,0"/>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -26,7 +26,7 @@ namespace GTDCompanion
             }
             if (closeBtn is not null)
             {
-                closeBtn.Click += (_, _) => this.Close();
+                closeBtn.Click += (_, _) => this.Hide();
             }
             if (minBtn is not null)
             {
@@ -35,6 +35,7 @@ namespace GTDCompanion
 
             // Defer until UI is fully loaded
             this.Opened += async (_, _) => await InitWithLicenseCheck();
+            this.Closing += (_, e) => { e.Cancel = true; this.Hide(); };
         }
 
         // Arrastar janela pela barra custom
@@ -114,6 +115,11 @@ namespace GTDCompanion
         private void MacroPage_Click(object? sender, RoutedEventArgs e)
         {
             MainContent.Content = new MacroPage();
+        }
+
+        private void KeyboardMouseStatsPage_Click(object? sender, RoutedEventArgs e)
+        {
+            MainContent.Content = new KeyboardMouseStatsPage();
         }
 
         private void MenuSobre_Click(object? sender, RoutedEventArgs e)

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GTDCompanion.Pages.KeyboardMouseStatsPage"
+             Background="#2C2F33">
+    <StackPanel Margin="10" Spacing="8">
+        <TextBlock Text="Estatísticas de Teclado/Mouse" FontSize="20" FontWeight="Bold" Foreground="#FE6A0A" HorizontalAlignment="Center"/>
+        <TextBlock x:Name="KeyPressText" Foreground="White"/>
+        <TextBlock x:Name="LeftClickText" Foreground="White"/>
+        <TextBlock x:Name="RightClickText" Foreground="White"/>
+        <TextBlock x:Name="ScrollText" Foreground="White"/>
+        <TextBlock x:Name="TopKeysText" Foreground="White"/>
+    </StackPanel>
+</UserControl>

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using GTDCompanion.Helpers;
+using System.Linq;
+
+namespace GTDCompanion.Pages
+{
+    public partial class KeyboardMouseStatsPage : UserControl
+    {
+        public KeyboardMouseStatsPage()
+        {
+            InitializeComponent();
+            StatsTracker.StatsUpdated += (_, __) => UpdateStats();
+            UpdateStats();
+        }
+
+        private void UpdateStats()
+        {
+            var s = StatsTracker.Stats;
+            KeyPressText.Text = $"Teclas pressionadas: {s.KeyPresses}";
+            LeftClickText.Text = $"Cliques esquerdo: {s.LeftClicks}";
+            RightClickText.Text = $"Cliques direito: {s.RightClicks}";
+            double meters = s.ScrollTicks * 0.01;
+            ScrollText.Text = $"Scroll: {meters:F2} m";
+            var top3 = s.KeyCounts.OrderByDescending(kv => kv.Value).Take(3)
+                .Select(kv => $"{(Avalonia.Input.Key)kv.Key} ({kv.Value})");
+            TopKeysText.Text = "Top 3 teclas: " + string.Join(", ", top3);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track global keyboard and mouse events
- persist statistics in the existing config
- show statistics on a new `KeyboardMouseStatsPage`
- hide main window to tray instead of closing
- add tray icon with exit menu
- wire new page into menu

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844bcca1dec832ab4012c5c5b44f5f5