### PR TITLE
Fix scroll stats and key names, add Discord tray link

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -42,12 +42,24 @@ namespace GTDCompanion
                     ToolTipText = "GTD Companion"
                 };
                 var menu = new NativeMenu();
+                var discordItem = new NativeMenuItem("Acesse o Discord");
+                discordItem.Click += (_, __) =>
+                {
+                    var psi = new ProcessStartInfo
+                    {
+                        FileName = "https://discord.gg/bDNcp6cs8J",
+                        UseShellExecute = true
+                    };
+                    Process.Start(psi);
+                };
+
                 var exitItem = new NativeMenuItem("Encerrar");
                 exitItem.Click += (_, __) =>
                 {
                     StatsTracker.Stop();
                     desktop.Shutdown();
                 };
+                menu.Items.Add(discordItem);
                 menu.Items.Add(exitItem);
                 tray.Menu = menu;
                 tray.Clicked += (_, __) =>

--- a/Helpers/StatsTracker.cs
+++ b/Helpers/StatsTracker.cs
@@ -30,7 +30,7 @@ namespace GTDCompanion.Helpers
             Stats.KeyPresses = GTDConfigHelper.GetInt("Stats", "KeyPresses", 0);
             Stats.LeftClicks = GTDConfigHelper.GetInt("Stats", "LeftClicks", 0);
             Stats.RightClicks = GTDConfigHelper.GetInt("Stats", "RightClicks", 0);
-            Stats.ScrollTicks = GTDConfigHelper.GetInt("Stats", "ScrollTicks", 0);
+            Stats.ScrollTicks = Math.Abs(GTDConfigHelper.GetInt("Stats", "ScrollTicks", 0));
             var json = GTDConfigHelper.Get("Stats", "KeyCounts", "{}");
             try
             {
@@ -113,7 +113,7 @@ namespace GTDCompanion.Helpers
                     case WM_MOUSEWHEEL:
                         var m = Marshal.PtrToStructure<MSLLHOOKSTRUCT>(lParam);
                         int delta = (short)((m.mouseData >> 16) & 0xffff);
-                        Stats.ScrollTicks += delta / 120;
+                        Stats.ScrollTicks += Math.Abs(delta) / 120;
                         break;
                 }
                 Save();

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using GTDCompanion.Helpers;
 using System.Linq;
+using WindowsInput.Native;
 
 namespace GTDCompanion.Pages
 {
@@ -22,7 +23,13 @@ namespace GTDCompanion.Pages
             double meters = s.ScrollTicks * 0.01;
             ScrollText.Text = $"Scroll: {meters:F2} m";
             var top3 = s.KeyCounts.OrderByDescending(kv => kv.Value).Take(3)
-                .Select(kv => $"{(Avalonia.Input.Key)kv.Key} ({kv.Value})");
+                .Select(kv =>
+                {
+                    var name = System.Enum.GetName(typeof(WindowsInput.Native.VirtualKeyCode), kv.Key);
+                    if (name != null && name.StartsWith("VK_"))
+                        name = name.Substring(3);
+                    return $"{name} ({kv.Value})";
+                });
             TopKeysText.Text = "Top 3 teclas: " + string.Join(", ", top3);
         }
     }


### PR DESCRIPTION
## Summary
- keep scroll tick total positive by summing absolute wheel delta
- show the correct key names in KeyboardMouseStatsPage
- add "Acesse o Discord" entry to tray menu

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bfd6ba70832a8c8d7db9f166db8d