### PR TITLE
Add persistent daily click stats

### DIFF
--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml
@@ -7,6 +7,9 @@
         <TextBlock x:Name="KeyPressText" Foreground="White"/>
         <TextBlock x:Name="LeftClickText" Foreground="White"/>
         <TextBlock x:Name="RightClickText" Foreground="White"/>
+        <TextBlock x:Name="TodayClicksText" Foreground="White"/>
+        <TextBlock x:Name="WeekClicksText" Foreground="White"/>
+        <TextBlock x:Name="YearClicksText" Foreground="White"/>
         <TextBlock x:Name="ScrollText" Foreground="White"/>
         <TextBlock x:Name="TopKeysText" Foreground="White"/>
     </StackPanel>

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using GTDCompanion.Helpers;
 using System.Linq;
+using System;
 using WindowsInput.Native;
 
 namespace GTDCompanion.Pages
@@ -20,6 +21,23 @@ namespace GTDCompanion.Pages
             KeyPressText.Text = $"Teclas pressionadas: {s.KeyPresses}";
             LeftClickText.Text = $"Cliques esquerdo: {s.LeftClicks}";
             RightClickText.Text = $"Cliques direito: {s.RightClicks}";
+
+            var todayKey = DateTime.Now.ToString("yyyy-MM-dd");
+            s.DailyClicks.TryGetValue(todayKey, out int today);
+            TodayClicksText.Text = $"Cliques hoje: {today}";
+
+            DateTime startWeek = DateTime.Now.Date.AddDays(-6);
+            int week = s.DailyClicks
+                .Where(kv => DateTime.TryParse(kv.Key, out var d) && d >= startWeek)
+                .Sum(kv => kv.Value);
+            WeekClicksText.Text = $"Últimos 7 dias: {week}";
+
+            DateTime startYear = DateTime.Now.Date.AddMonths(-12);
+            int year = s.DailyClicks
+                .Where(kv => DateTime.TryParse(kv.Key, out var d) && d >= startYear)
+                .Sum(kv => kv.Value);
+            YearClicksText.Text = $"Últimos 12 meses: {year}";
+
             double meters = s.ScrollTicks * 0.01;
             ScrollText.Text = $"Scroll: {meters:F2} m";
             var top3 = s.KeyCounts.OrderByDescending(kv => kv.Value).Take(3)


### PR DESCRIPTION
## Summary
- store keyboard/mouse stats into a json file in the config directory
- record daily click counts for today/last week/last year
- show dynamic daily/weekly/yearly click totals in the stats page

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844c3303c48832ab1507d079a54fc46