### PR TITLE
Fix stats persistence on restart

### DIFF
--- a/Helpers/StatsTracker.cs
+++ b/Helpers/StatsTracker.cs
@@ -13,8 +13,8 @@ namespace GTDCompanion.Helpers
         public int LeftClicks { get; set; }
         public int RightClicks { get; set; }
         public int ScrollTicks { get; set; }
-        public Dictionary<int, int> KeyCounts { get; } = new();
-        public Dictionary<string, int> DailyClicks { get; } = new();
+        public Dictionary<int, int> KeyCounts { get; set; } = new();
+        public Dictionary<string, int> DailyClicks { get; set; } = new();
     }
 
     public static class StatsTracker


### PR DESCRIPTION
## Summary
- fix `KeyboardMouseStats` so key and click dictionaries are deserializable

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844c6e81610832aac5624dcfcebe92a