### PR TITLE
Add keyboard daily stats

### DIFF
--- a/Helpers/StatsTracker.cs
+++ b/Helpers/StatsTracker.cs
@@ -15,6 +15,7 @@ namespace GTDCompanion.Helpers
         public int ScrollTicks { get; set; }
         public Dictionary<int, int> KeyCounts { get; set; } = new();
         public Dictionary<string, int> DailyClicks { get; set; } = new();
+        public Dictionary<string, int> DailyKeyPresses { get; set; } = new();
     }
 
     public static class StatsTracker
@@ -52,6 +53,12 @@ namespace GTDCompanion.Helpers
                         Stats.DailyClicks.Clear();
                         foreach (var kv in loaded.DailyClicks)
                             Stats.DailyClicks[kv.Key] = kv.Value;
+                        Stats.DailyKeyPresses.Clear();
+                        if (loaded.DailyKeyPresses != null)
+                        {
+                            foreach (var kv in loaded.DailyKeyPresses)
+                                Stats.DailyKeyPresses[kv.Key] = kv.Value;
+                        }
                         return;
                     }
                 }
@@ -97,6 +104,14 @@ namespace GTDCompanion.Helpers
             Stats.DailyClicks[key]++;
         }
 
+        private static void IncrementDailyKeyPresses()
+        {
+            var key = DateTime.Now.ToString("yyyy-MM-dd");
+            if (!Stats.DailyKeyPresses.ContainsKey(key))
+                Stats.DailyKeyPresses[key] = 0;
+            Stats.DailyKeyPresses[key]++;
+        }
+
         public static void Start()
         {
             if (!OperatingSystem.IsWindows())
@@ -135,6 +150,7 @@ namespace GTDCompanion.Helpers
                 if (!Stats.KeyCounts.ContainsKey(info.vkCode))
                     Stats.KeyCounts[info.vkCode] = 0;
                 Stats.KeyCounts[info.vkCode]++;
+                IncrementDailyKeyPresses();
                 Save();
                 StatsUpdated?.Invoke();
             }

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml
@@ -4,13 +4,24 @@
              Background="#2C2F33">
     <StackPanel Margin="10" Spacing="8">
         <TextBlock Text="Estatísticas de Teclado/Mouse" FontSize="20" FontWeight="Bold" Foreground="#FE6A0A" HorizontalAlignment="Center"/>
-        <TextBlock x:Name="KeyPressText" Foreground="White"/>
-        <TextBlock x:Name="LeftClickText" Foreground="White"/>
-        <TextBlock x:Name="RightClickText" Foreground="White"/>
-        <TextBlock x:Name="TodayClicksText" Foreground="White"/>
-        <TextBlock x:Name="WeekClicksText" Foreground="White"/>
-        <TextBlock x:Name="YearClicksText" Foreground="White"/>
-        <TextBlock x:Name="ScrollText" Foreground="White"/>
-        <TextBlock x:Name="TopKeysText" Foreground="White"/>
+        <Grid ColumnDefinitions="*,*" ColumnSpacing="20">
+            <StackPanel Grid.Column="0" Spacing="4">
+                <TextBlock Text="Teclado" FontSize="16" FontWeight="Bold" Foreground="#FE6A0A"/>
+                <TextBlock x:Name="KeyPressText" Foreground="White"/>
+                <TextBlock x:Name="TodayKeysText" Foreground="White"/>
+                <TextBlock x:Name="WeekKeysText" Foreground="White"/>
+                <TextBlock x:Name="YearKeysText" Foreground="White"/>
+                <TextBlock x:Name="TopKeysText" Foreground="White"/>
+            </StackPanel>
+            <StackPanel Grid.Column="1" Spacing="4">
+                <TextBlock Text="Mouse" FontSize="16" FontWeight="Bold" Foreground="#FE6A0A"/>
+                <TextBlock x:Name="LeftClickText" Foreground="White"/>
+                <TextBlock x:Name="RightClickText" Foreground="White"/>
+                <TextBlock x:Name="TodayClicksText" Foreground="White"/>
+                <TextBlock x:Name="WeekClicksText" Foreground="White"/>
+                <TextBlock x:Name="YearClicksText" Foreground="White"/>
+                <TextBlock x:Name="ScrollText" Foreground="White"/>
+            </StackPanel>
+        </Grid>
     </StackPanel>
 </UserControl>

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -23,20 +23,30 @@ namespace GTDCompanion.Pages
             RightClickText.Text = $"Cliques direito: {s.RightClicks}";
 
             var todayKey = DateTime.Now.ToString("yyyy-MM-dd");
-            s.DailyClicks.TryGetValue(todayKey, out int today);
-            TodayClicksText.Text = $"Cliques hoje: {today}";
+            s.DailyKeyPresses.TryGetValue(todayKey, out int todayKeys);
+            TodayKeysText.Text = $"Teclas hoje: {todayKeys}";
+            s.DailyClicks.TryGetValue(todayKey, out int todayClicks);
+            TodayClicksText.Text = $"Cliques hoje: {todayClicks}";
 
             DateTime startWeek = DateTime.Now.Date.AddDays(-6);
-            int week = s.DailyClicks
+            int weekKeys = s.DailyKeyPresses
                 .Where(kv => DateTime.TryParse(kv.Key, out var d) && d >= startWeek)
                 .Sum(kv => kv.Value);
-            WeekClicksText.Text = $"Últimos 7 dias: {week}";
+            WeekKeysText.Text = $"Últimos 7 dias: {weekKeys}";
+            int weekClicks = s.DailyClicks
+                .Where(kv => DateTime.TryParse(kv.Key, out var d) && d >= startWeek)
+                .Sum(kv => kv.Value);
+            WeekClicksText.Text = $"Últimos 7 dias: {weekClicks}";
 
             DateTime startYear = DateTime.Now.Date.AddMonths(-12);
-            int year = s.DailyClicks
+            int yearKeys = s.DailyKeyPresses
                 .Where(kv => DateTime.TryParse(kv.Key, out var d) && d >= startYear)
                 .Sum(kv => kv.Value);
-            YearClicksText.Text = $"Últimos 12 meses: {year}";
+            YearKeysText.Text = $"Últimos 12 meses: {yearKeys}";
+            int yearClicks = s.DailyClicks
+                .Where(kv => DateTime.TryParse(kv.Key, out var d) && d >= startYear)
+                .Sum(kv => kv.Value);
+            YearClicksText.Text = $"Últimos 12 meses: {yearClicks}";
 
             double meters = s.ScrollTicks * 0.01;
             ScrollText.Text = $"Scroll: {meters:F2} m";


### PR DESCRIPTION
## Summary
- track keyboard daily keypresses in `StatsTracker`
- show today's, weekly and yearly keyboard stats alongside mouse stats
- rearrange keyboard/mouse stats page layout for clarity

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c847955c832a824636af213b2604