### PR TITLE
Add mouse movement and computer uptime stats

### DIFF
--- a/Helpers/StatsTracker.cs
+++ b/Helpers/StatsTracker.cs
@@ -13,6 +13,9 @@ namespace GTDCompanion.Helpers
         public int LeftClicks { get; set; }
         public int RightClicks { get; set; }
         public int ScrollTicks { get; set; }
+        public double MousePixelsMoved { get; set; }
+        public TimeSpan IdleTime { get; set; }
+        public DateTime LastMaintenance { get; set; } = DateTime.Now;
         public Dictionary<int, int> KeyCounts { get; set; } = new();
         public Dictionary<string, int> DailyClicks { get; set; } = new();
         public Dictionary<string, int> DailyKeyPresses { get; set; } = new();
@@ -30,6 +33,11 @@ namespace GTDCompanion.Helpers
         private static IntPtr _mouseHook;
         private static LowLevelProc? _keyboardProc;
         private static LowLevelProc? _mouseProc;
+        private static System.Timers.Timer? _timer;
+        private static POINT _lastPoint;
+        private static bool _hasLastPoint;
+        private static DateTime _lastMouseMove = DateTime.Now;
+        public static DateTime StartTime { get; private set; } = DateTime.Now;
 
         public static event Action? StatsUpdated;
 
@@ -47,6 +55,10 @@ namespace GTDCompanion.Helpers
                         Stats.LeftClicks = loaded.LeftClicks;
                         Stats.RightClicks = loaded.RightClicks;
                         Stats.ScrollTicks = loaded.ScrollTicks;
+                        Stats.MousePixelsMoved = loaded.MousePixelsMoved;
+                        Stats.IdleTime = loaded.IdleTime;
+                        if (loaded.LastMaintenance != DateTime.MinValue)
+                            Stats.LastMaintenance = loaded.LastMaintenance;
                         Stats.KeyCounts.Clear();
                         foreach (var kv in loaded.KeyCounts)
                             Stats.KeyCounts[kv.Key] = kv.Value;
@@ -118,10 +130,21 @@ namespace GTDCompanion.Helpers
                 return;
             if (_keyboardHook != IntPtr.Zero)
                 return;
+            StartTime = DateTime.Now;
+            _lastMouseMove = DateTime.Now;
             _keyboardProc = KeyboardHookCallback;
             _mouseProc = MouseHookCallback;
             _keyboardHook = SetWindowsHookEx(WH_KEYBOARD_LL, _keyboardProc, GetModuleHandle(null), 0);
             _mouseHook = SetWindowsHookEx(WH_MOUSE_LL, _mouseProc, GetModuleHandle(null), 0);
+            _timer = new System.Timers.Timer(60000);
+            _timer.Elapsed += (_, __) => {
+                if (DateTime.Now - _lastMouseMove >= TimeSpan.FromMinutes(1))
+                    Stats.IdleTime += TimeSpan.FromMinutes(1);
+                Save();
+                StatsUpdated?.Invoke();
+            };
+            _timer.AutoReset = true;
+            _timer.Start();
         }
 
         public static void Stop()
@@ -138,6 +161,19 @@ namespace GTDCompanion.Helpers
                 UnhookWindowsHookEx(_mouseHook);
                 _mouseHook = IntPtr.Zero;
             }
+            if (_timer != null)
+            {
+                _timer.Stop();
+                _timer.Dispose();
+                _timer = null;
+            }
+        }
+
+        public static void ResetMaintenance()
+        {
+            Stats.LastMaintenance = DateTime.Now;
+            Save();
+            StatsUpdated?.Invoke();
         }
 
         private static IntPtr KeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
@@ -151,7 +187,6 @@ namespace GTDCompanion.Helpers
                     Stats.KeyCounts[info.vkCode] = 0;
                 Stats.KeyCounts[info.vkCode]++;
                 IncrementDailyKeyPresses();
-                Save();
                 StatsUpdated?.Invoke();
             }
             return CallNextHookEx(_keyboardHook, nCode, wParam, lParam);
@@ -166,18 +201,33 @@ namespace GTDCompanion.Helpers
                     case WM_LBUTTONDOWN:
                         Stats.LeftClicks++;
                         IncrementDailyClicks();
+                        _lastMouseMove = DateTime.Now;
                         break;
                     case WM_RBUTTONDOWN:
                         Stats.RightClicks++;
                         IncrementDailyClicks();
+                        _lastMouseMove = DateTime.Now;
                         break;
                     case WM_MOUSEWHEEL:
                         var m = Marshal.PtrToStructure<MSLLHOOKSTRUCT>(lParam);
                         int delta = (short)((m.mouseData >> 16) & 0xffff);
                         Stats.ScrollTicks += Math.Abs(delta) / 120;
+                        _lastMouseMove = DateTime.Now;
+                        break;
+                    case WM_MOUSEMOVE:
+                        var mm = Marshal.PtrToStructure<MSLLHOOKSTRUCT>(lParam);
+                        if (_hasLastPoint)
+                        {
+                            int dx = mm.pt.x - _lastPoint.x;
+                            int dy = mm.pt.y - _lastPoint.y;
+                            double dist = Math.Sqrt(dx * dx + dy * dy);
+                            Stats.MousePixelsMoved += dist;
+                        }
+                        _lastPoint = mm.pt;
+                        _hasLastPoint = true;
+                        _lastMouseMove = DateTime.Now;
                         break;
                 }
-                Save();
                 StatsUpdated?.Invoke();
             }
             return CallNextHookEx(_mouseHook, nCode, wParam, lParam);
@@ -191,6 +241,7 @@ namespace GTDCompanion.Helpers
         private const int WM_LBUTTONDOWN = 0x0201;
         private const int WM_RBUTTONDOWN = 0x0204;
         private const int WM_MOUSEWHEEL = 0x020A;
+        private const int WM_MOUSEMOVE = 0x0200;
 
         [StructLayout(LayoutKind.Sequential)]
         private struct POINT { public int x; public int y; }

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml
@@ -21,7 +21,15 @@
                 <TextBlock x:Name="WeekClicksText" Foreground="White"/>
                 <TextBlock x:Name="YearClicksText" Foreground="White"/>
                 <TextBlock x:Name="ScrollText" Foreground="White"/>
+                <TextBlock x:Name="DistanceText" Foreground="White"/>
             </StackPanel>
         </Grid>
+        <StackPanel Spacing="4" Margin="0,10,0,0">
+            <TextBlock Text="Computador" FontSize="16" FontWeight="Bold" Foreground="#FE6A0A"/>
+            <TextBlock x:Name="UptimeText" Foreground="White"/>
+            <TextBlock x:Name="IdleText" Foreground="White"/>
+            <TextBlock x:Name="MaintenanceText" Foreground="White"/>
+            <Button Content="Resetar manutenção" Click="ResetMaintenance_Click"/>
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -3,6 +3,7 @@ using GTDCompanion.Helpers;
 using System.Linq;
 using System;
 using WindowsInput.Native;
+using Avalonia.Interactivity;
 
 namespace GTDCompanion.Pages
 {
@@ -50,6 +51,8 @@ namespace GTDCompanion.Pages
 
             double meters = s.ScrollTicks * 0.01;
             ScrollText.Text = $"Scroll: {meters:F2} m";
+            double dist = s.MousePixelsMoved * 0.00026;
+            DistanceText.Text = $"Distância: {dist:F2} m";
             var top3 = s.KeyCounts.OrderByDescending(kv => kv.Value).Take(3)
                 .Select(kv =>
                 {
@@ -59,6 +62,17 @@ namespace GTDCompanion.Pages
                     return $"{name} ({kv.Value})";
                 });
             TopKeysText.Text = "Top 3 teclas: " + string.Join(", ", top3);
+
+            TimeSpan up = DateTime.Now - StatsTracker.StartTime;
+            UptimeText.Text = $"Tempo de atividade: {up:dd\\:hh\\:mm}";
+            IdleText.Text = $"Tempo ocioso: {s.IdleTime:dd\\:hh\\:mm}";
+            TimeSpan sinceMaint = DateTime.Now - s.LastMaintenance;
+            MaintenanceText.Text = $"Desde manutenção: {sinceMaint:dd\\:hh\\:mm}";
+        }
+
+        private void ResetMaintenance_Click(object? sender, RoutedEventArgs e)
+        {
+            StatsTracker.ResetMaintenance();
         }
     }
 }


### PR DESCRIPTION
## Summary
- track mouse pixel movement and idle time in `StatsTracker`
- periodically save stats each minute
- add UI elements for mouse distance, computer uptime, idle time, and maintenance timer
- allow resetting maintenance timer

## Testing
- `dotnet build -v q` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68455b3994b8832a859ac6dbff8de789