### PR TITLE
Fix time stats formatting

### DIFF
--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -64,10 +64,10 @@ namespace GTDCompanion.Pages
             TopKeysText.Text = "Top 3 teclas: " + string.Join(", ", top3);
 
             TimeSpan up = DateTime.Now - StatsTracker.StartTime;
-            UptimeText.Text = $"Tempo de atividade: {up:dd\\:hh\\:mm}";
-            IdleText.Text = $"Tempo ocioso: {s.IdleTime:dd\\:hh\\:mm}";
+            UptimeText.Text = $"Tempo de atividade: {up:dd\\:hh\\:mm\\:ss}";
+            IdleText.Text = $"Tempo ocioso: {s.IdleTime:dd\\:hh\\:mm\\:ss}";
             TimeSpan sinceMaint = DateTime.Now - s.LastMaintenance;
-            MaintenanceText.Text = $"Desde manutenção: {sinceMaint:dd\\:hh\\:mm}";
+            MaintenanceText.Text = $"Desde manutenção: {sinceMaint:dd\\:hh\\:mm\\:ss}";
         }
 
         private void ResetMaintenance_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- show seconds in computer time statistics

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455e2ea1c8832aad0caba7e2858721