### PR TITLE
Ensure stats page time updates

### DIFF
--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -4,16 +4,22 @@ using System.Linq;
 using System;
 using WindowsInput.Native;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 
 namespace GTDCompanion.Pages
 {
     public partial class KeyboardMouseStatsPage : UserControl
     {
+        private readonly DispatcherTimer _updateTimer;
+
         public KeyboardMouseStatsPage()
         {
             InitializeComponent();
             StatsTracker.StatsUpdated += () => UpdateStats();
             UpdateStats();
+            _updateTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+            _updateTimer.Tick += (_, __) => UpdateStats();
+            _updateTimer.Start();
         }
 
         private void UpdateStats()


### PR DESCRIPTION
## Summary
- make keyboard/mouse stats display refresh every second

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456017d7b4832a8573b823a572b509