### PR TITLE
Add overall activity time tracking to stats

### DIFF
--- a/Helpers/StatsTracker.cs
+++ b/Helpers/StatsTracker.cs
@@ -15,6 +15,7 @@ namespace GTDCompanion.Helpers
         public int ScrollTicks { get; set; }
         public double MousePixelsMoved { get; set; }
         public TimeSpan IdleTime { get; set; }
+        public TimeSpan ActiveTime { get; set; }
         public DateTime LastMaintenance { get; set; } = DateTime.Now;
         public Dictionary<int, int> KeyCounts { get; set; } = new();
         public Dictionary<string, int> DailyClicks { get; set; } = new();
@@ -57,6 +58,7 @@ namespace GTDCompanion.Helpers
                         Stats.ScrollTicks = loaded.ScrollTicks;
                         Stats.MousePixelsMoved = loaded.MousePixelsMoved;
                         Stats.IdleTime = loaded.IdleTime;
+                        Stats.ActiveTime = loaded.ActiveTime;
                         if (loaded.LastMaintenance != DateTime.MinValue)
                             Stats.LastMaintenance = loaded.LastMaintenance;
                         Stats.KeyCounts.Clear();
@@ -140,6 +142,8 @@ namespace GTDCompanion.Helpers
             _timer.Elapsed += (_, __) => {
                 if (DateTime.Now - _lastMouseMove >= TimeSpan.FromMinutes(1))
                     Stats.IdleTime += TimeSpan.FromMinutes(1);
+                else
+                    Stats.ActiveTime += TimeSpan.FromMinutes(1);
                 Save();
                 StatsUpdated?.Invoke();
             };

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml
@@ -28,6 +28,7 @@
             <TextBlock Text="Computador" FontSize="16" FontWeight="Bold" Foreground="#FE6A0A"/>
             <TextBlock x:Name="UptimeText" Foreground="White"/>
             <TextBlock x:Name="IdleText" Foreground="White"/>
+            <TextBlock x:Name="ActiveTimeText" Foreground="White"/>
             <TextBlock x:Name="MaintenanceText" Foreground="White"/>
             <Button Content="Resetar manutenção" Click="ResetMaintenance_Click"/>
         </StackPanel>

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -72,6 +72,7 @@ namespace GTDCompanion.Pages
             TimeSpan up = DateTime.Now - StatsTracker.StartTime;
             UptimeText.Text = $"Tempo de atividade: {up:dd\\:hh\\:mm\\:ss}";
             IdleText.Text = $"Tempo ocioso: {s.IdleTime:dd\\:hh\\:mm\\:ss}";
+            ActiveTimeText.Text = $"Tempo de atividade geral: {s.ActiveTime:dd\\:hh\\:mm\\:ss}";
             TimeSpan sinceMaint = DateTime.Now - s.LastMaintenance;
             MaintenanceText.Text = $"Desde manutenção: {sinceMaint:dd\\:hh\\:mm\\:ss}";
         }


### PR DESCRIPTION
## Summary
- track overall activity time in `StatsTracker`
- display the value on the Keyboard/Mouse Stats page

## Testing
- `dotnet build GTDCompanion.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684563be41e4832abb0c688b8fabe034