### PR TITLE
Fix overlay reopens

### DIFF
--- a/Pages/BenchmarkOverlay/BenchmarkOverlayPage.axaml.cs
+++ b/Pages/BenchmarkOverlay/BenchmarkOverlayPage.axaml.cs
@@ -15,7 +15,7 @@ namespace GTDCompanion.Pages
 {
     public partial class BenchmarkOverlayPage : UserControl
     {
-        private BenchmarkOverlayWindow? overlayWindow;
+        private static BenchmarkOverlayWindow? overlayWindow;
         private bool rtssAvailable = false;
 
         private readonly string[] possibleRtssPaths = new[]
@@ -31,6 +31,12 @@ namespace GTDCompanion.Pages
 
         // Helper para evitar duplo-save
         private bool loadingSettings = false;
+
+        private void UpdateToggleButton()
+        {
+            ShowOverlayBtn.Content = (overlayWindow != null && overlayWindow.IsVisible)
+                ? "Ocultar Benchmark" : "Mostrar Benchmark";
+        }
 
         public BenchmarkOverlayPage()
         {
@@ -60,7 +66,10 @@ namespace GTDCompanion.Pages
             {
                 rtssAvailable = await CheckAndStartRTSS();
                 SetRtssUi(rtssAvailable);
+                UpdateToggleButton();
             });
+
+            UpdateToggleButton();
         }
 
         private async void ShowOverlayBtn_Click(object? sender, RoutedEventArgs e)
@@ -78,6 +87,7 @@ namespace GTDCompanion.Pages
                 await Task.Run(() => KillRtssProcesses());
                 rtssAvailable = false;
                 SetRtssUi(false);
+                UpdateToggleButton();
                 return;
             }
 
@@ -91,10 +101,11 @@ namespace GTDCompanion.Pages
             }
 
             overlayWindow = new BenchmarkOverlayWindow(GetOverlaySettings());
-            overlayWindow.Closed += (_, _) => overlayWindow = null;
+            overlayWindow.Closed += (_, _) => { overlayWindow = null; UpdateToggleButton(); };
             overlayWindow.Show();
             rtssAvailable = true;
             SetRtssUi(true);
+            UpdateToggleButton();
         }
 
         private void DownloadRtssBtn_Click(object? sender, RoutedEventArgs e)

--- a/Pages/MiraOverlay/MiraPage.axaml.cs
+++ b/Pages/MiraOverlay/MiraPage.axaml.cs
@@ -11,9 +11,15 @@ namespace GTDCompanion.Pages
 {
     public partial class MiraPage : UserControl
     {
-        private OverlayWindow? overlayWin;
+        private static OverlayWindow? overlayWin;
         private bool isLoaded = false; // Evita trigger duplo ao carregar
         private GlobalHotkey? globalHotkey;
+
+        private void UpdateToggleButton()
+        {
+            ToggleBtn.Content = (overlayWin != null && overlayWin.IsVisible)
+                ? "Ocultar Mira" : "Mostrar Mira";
+        }
 
         public MiraPage()
         {
@@ -63,6 +69,8 @@ namespace GTDCompanion.Pages
                     win.KeyDown -= OnWindowKeyDown;
                 globalHotkey?.Dispose();
             };
+
+            UpdateToggleButton();
         }
 
         private void ToggleMira_Click(object? sender, RoutedEventArgs e)
@@ -70,16 +78,17 @@ namespace GTDCompanion.Pages
             if (overlayWin == null || !overlayWin.IsVisible)
             {
                 overlayWin = new OverlayWindow();
+                overlayWin.Closed += (_, __) => { overlayWin = null; UpdateToggleButton(); };
                 overlayWin.Show();
                 overlayWin.UpdateMira(GetCurrentConfig());
-                ToggleBtn.Content = "Ocultar Mira";
             }
             else
             {
                 overlayWin.Close();
                 overlayWin = null;
-                ToggleBtn.Content = "Mostrar Mira";
             }
+
+            UpdateToggleButton();
         }
 
         private void OnConfigChanged(object? sender, EventArgs? e)

--- a/Pages/StickerNotes/StickerNotesPage.axaml.cs
+++ b/Pages/StickerNotes/StickerNotesPage.axaml.cs
@@ -6,9 +6,18 @@ namespace GTDCompanion.Pages
 {
     public partial class StickerNotesPage : UserControl
     {
-        private readonly StickerNoteWindow?[] windows = new StickerNoteWindow?[5];
+        private static readonly StickerNoteWindow?[] windows = new StickerNoteWindow?[5];
         private readonly IBrush?[] defaultBackgrounds = new IBrush?[5];
         private readonly IBrush openBrush = new SolidColorBrush(Color.Parse("#FE6A0A"));
+
+        private void UpdateButtonStates()
+        {
+            for (int i = 0; i < windows.Length; i++)
+            {
+                var btn = GetButton(i);
+                btn.Background = (windows[i] != null && windows[i]!.IsVisible) ? openBrush : defaultBackgrounds[i];
+            }
+        }
 
         public StickerNotesPage()
         {
@@ -23,6 +32,8 @@ namespace GTDCompanion.Pages
             Note3Button.Click += (_, __) => ToggleWindow(2);
             Note4Button.Click += (_, __) => ToggleWindow(3);
             Note5Button.Click += (_, __) => ToggleWindow(4);
+
+            UpdateButtonStates();
         }
 
         private Button GetButton(int idx) => idx switch
@@ -36,7 +47,6 @@ namespace GTDCompanion.Pages
 
         private void ToggleWindow(int idx)
         {
-            var btn = GetButton(idx);
             if (windows[idx] == null || !windows[idx]!.IsVisible)
             {
                 var win = new StickerNoteWindow(idx + 1);
@@ -44,17 +54,17 @@ namespace GTDCompanion.Pages
                 win.Closed += (_, __) =>
                 {
                     windows[idx] = null;
-                    btn.Background = defaultBackgrounds[idx];
+                    UpdateButtonStates();
                 };
                 win.Show();
-                btn.Background = openBrush;
             }
             else
             {
                 windows[idx]!.Close();
                 windows[idx] = null;
-                btn.Background = defaultBackgrounds[idx];
             }
+
+            UpdateButtonStates();
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep overlay window references static so pages detect already open windows
- update toggle buttons for overlay windows
- update sticker note page to track window state and reflect open notes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684579bad428832aaa85fc9d33b616b8