### PR TITLE
Fix icon loading for published app

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System;
 using System.Diagnostics;
 using System.Linq;
+using Avalonia.Platform;
 using dotenv.net;
 
 
@@ -46,7 +47,7 @@ namespace GTDCompanion
 
                 var tray = new TrayIcon
                 {
-                    Icon = new WindowIcon("Assets/icon.ico"),
+                    Icon = new WindowIcon(AssetLoader.Open(new Uri("avares://GTDCompanion/Assets/icon.ico"))),
                     ToolTipText = "GTD Companion"
                 };
                 var menu = new NativeMenu();

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -5,7 +5,7 @@
     xmlns:pages="clr-namespace:GTDCompanion.Pages"
     x:Class="GTDCompanion.MainWindow"
     Title="GTD Companion"
-    Icon="/Assets/icon.ico"
+    Icon="avares://GTDCompanion/Assets/icon.ico"
     Width="900" 
     MinHeight="500"
     WindowStartupLocation="CenterScreen"

--- a/Pages/TranslatorAI/TranslatorOverlay.axaml
+++ b/Pages/TranslatorAI/TranslatorOverlay.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="GTDCompanion.Pages.TranslatorOverlay"
         Width="400" Height="250"
-        Icon="/Assets/icon.ico"
+        Icon="avares://GTDCompanion/Assets/icon.ico"
         BorderThickness="0"
         CanResize="False"
         Topmost="True"


### PR DESCRIPTION
## Summary
- use asset loader to build tray icon
- update window icons to use avares URI

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684593599598832a93defcd618c03121