### PR TITLE
Fix env loading

### DIFF
--- a/GTDCompanion.csproj
+++ b/GTDCompanion.csproj
@@ -41,7 +41,10 @@
     
     <AvaloniaResource Include="Assets\logo.png" />
     <AvaloniaResource Include="Assets\icon.ico" />
-    <AvaloniaResource Include=".env" />
+    <!-- Copy .env to output so DotEnv can load variables at runtime -->
+    <None Update=".env">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <AvaloniaResource Include=".changelog" />
 
     <Reference Include="RTSSSharedMemoryNET">


### PR DESCRIPTION
## Summary
- ensure `.env` file is copied to the build output so `DotEnv` can load variables at runtime

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684599bc7c20832aabc52c8d0a4c3ce6