### PR TITLE
Implement download progress for updates

### DIFF
--- a/Helpers/UpdateDownloader.cs
+++ b/Helpers/UpdateDownloader.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace GTDCompanion.Helpers
+{
+    public static class UpdateDownloader
+    {
+        public static async Task<string> DownloadAsync(string url, IProgress<double>? progress = null)
+        {
+            var target = Path.Combine(Path.GetTempPath(), "GTDCompanion_Installer.exe");
+            using var client = new HttpClient();
+            using var resp = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+            resp.EnsureSuccessStatusCode();
+            var total = resp.Content.Headers.ContentLength ?? -1L;
+            await using var stream = await resp.Content.ReadAsStreamAsync();
+            await using var fs = File.Create(target);
+            var buffer = new byte[81920];
+            long read;
+            long totalRead = 0;
+            while ((read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length))) > 0)
+            {
+                await fs.WriteAsync(buffer.AsMemory(0, (int)read));
+                totalRead += read;
+                if (total > 0 && progress != null)
+                {
+                    double pct = (double)totalRead / total * 100;
+                    progress.Report(pct);
+                }
+            }
+            progress?.Report(100);
+            return target;
+        }
+    }
+}

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -100,7 +100,8 @@
         <Border x:Name="UpdateBar" DockPanel.Dock="Bottom" Background="#333" Padding="5" IsVisible="False">
           <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
             <TextBlock x:Name="UpdateText" Foreground="White"/>
-            <Button Content="Atualizar" Click="UpdateNow_Click"/>
+            <Button x:Name="UpdateButton" Content="Atualizar" Click="UpdateNow_Click"/>
+            <TextBlock x:Name="UpdateProgress" Foreground="White" IsVisible="False"/>
           </StackPanel>
         </Border>
       </DockPanel>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using System;
+using GTDCompanion.Helpers;
 
 namespace GTDCompanion
 {
@@ -179,19 +180,19 @@ namespace GTDCompanion
         {
             try
             {
-                using var client = new HttpClient();
-                var temp = Path.Combine(Path.GetTempPath(), Path.GetFileName(url));
-                using var resp = await client.GetAsync(url);
-                resp.EnsureSuccessStatusCode();
-                await using (var fs = File.Create(temp))
-                {
-                    await resp.Content.CopyToAsync(fs);
-                }
+                UpdateProgress.IsVisible = true;
+                UpdateButton.IsEnabled = false;
+                var progress = new Progress<double>(p => UpdateProgress.Text = $"{p:0}%");
+                var temp = await UpdateDownloader.DownloadAsync(url, progress);
                 var psi = new ProcessStartInfo { FileName = temp, UseShellExecute = true };
                 Process.Start(psi);
                 Environment.Exit(0);
             }
-            catch { }
+            catch
+            {
+                UpdateButton.IsEnabled = true;
+                UpdateProgress.IsVisible = false;
+            }
         }
 
         private void StartUpdateTimer()

--- a/Pages/Update/MandatoryUpdatePage.axaml
+++ b/Pages/Update/MandatoryUpdatePage.axaml
@@ -5,7 +5,8 @@
     <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="15" Width="300">
       <TextBlock Text="Atualização obrigatória" Foreground="White" FontSize="20" TextAlignment="Center"/>
       <TextBlock x:Name="ChangelogText" Text="" Foreground="White" TextWrapping="Wrap" TextAlignment="Center"/>
-      <Button HorizontalAlignment="Center" Content="Atualizar" Click="OnUpdateClick"/>
+      <Button x:Name="UpdateButton" HorizontalAlignment="Center" Content="Atualizar" Click="OnUpdateClick"/>
+      <TextBlock x:Name="ProgressText" Text="" Foreground="White" HorizontalAlignment="Center" IsVisible="False"/>
     </StackPanel>
   </Border>
 </UserControl>

--- a/Pages/Update/MandatoryUpdatePage.axaml.cs
+++ b/Pages/Update/MandatoryUpdatePage.axaml.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
+using GTDCompanion.Helpers;
 using System.Threading.Tasks;
 
 namespace GTDCompanion.Pages
@@ -28,14 +29,10 @@ namespace GTDCompanion.Pages
                 return;
             try
             {
-                using var client = new HttpClient();
-                var tempFile = Path.Combine(Path.GetTempPath(), Path.GetFileName(DownloadUrl));
-                using var resp = await client.GetAsync(DownloadUrl);
-                resp.EnsureSuccessStatusCode();
-                await using (var fs = File.Create(tempFile))
-                {
-                    await resp.Content.CopyToAsync(fs);
-                }
+                ProgressText.IsVisible = true;
+                UpdateButton.IsEnabled = false;
+                var progress = new Progress<double>(p => ProgressText.Text = $"{p:0}%");
+                var tempFile = await UpdateDownloader.DownloadAsync(DownloadUrl, progress);
                 var psi = new ProcessStartInfo
                 {
                     FileName = tempFile,
@@ -47,6 +44,8 @@ namespace GTDCompanion.Pages
             catch
             {
                 // ignore
+                UpdateButton.IsEnabled = true;
+                ProgressText.IsVisible = false;
             }
         }
     }


### PR DESCRIPTION
## Summary
- display progress when downloading updates
- save updates as `GTDCompanion_Installer.exe`
- show progress text on the optional update bar and mandatory page
- add helper to download update files

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845cb3d6190832a8f3e4d2085f1b130