### PR TITLE
Improve update download flow

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -96,14 +96,6 @@
         </Menu>
         <!-- Conteúdo central dinâmico -->
         <ContentControl x:Name="MainContent" Margin="0,1,0,0"/>
-        <!-- Barra de atualização -->
-        <Border x:Name="UpdateBar" DockPanel.Dock="Bottom" Background="#333" Padding="5" IsVisible="False">
-          <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
-            <TextBlock x:Name="UpdateText" Foreground="White"/>
-            <Button x:Name="UpdateButton" Content="Atualizar" Click="UpdateNow_Click"/>
-            <TextBlock x:Name="UpdateProgress" Foreground="White" IsVisible="False"/>
-          </StackPanel>
-        </Border>
       </DockPanel>
     </Border>
 </Window>

--- a/Pages/HomePage.axaml
+++ b/Pages/HomePage.axaml
@@ -20,5 +20,10 @@
                    Foreground="#888"
                    FontSize="13"
                    FontWeight="Normal"/>
+        <StackPanel x:Name="UpdatePanel" IsVisible="False" Spacing="4" HorizontalAlignment="Center">
+            <TextBlock x:Name="UpdateText" Foreground="#ccc" FontSize="13" TextAlignment="Center"/>
+            <Button x:Name="UpdateButton" Content="Atualizar" Click="UpdateButton_Click"/>
+            <TextBlock x:Name="UpdateProgress" Foreground="#ccc" FontSize="13" TextAlignment="Center" IsVisible="False"/>
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/Pages/HomePage.axaml.cs
+++ b/Pages/HomePage.axaml.cs
@@ -1,10 +1,16 @@
 using Avalonia.Controls;
 using System.Diagnostics;
+using Avalonia.Interactivity;
+using GTDCompanion.Helpers;
+using System.Threading.Tasks;
 
 namespace GTDCompanion.Pages
 {
     public partial class HomePage : UserControl
     {
+        private string? _updateUrl;
+        private string? _downloadedFile;
+
         public HomePage()
         {
             InitializeComponent();
@@ -16,6 +22,50 @@ namespace GTDCompanion.Pages
                 var version = FileVersionInfo.GetVersionInfo(exePath).FileVersion;
                 VersionText.Text = $"Versão {version}";
             }
+        }
+
+        public void ShowOptionalUpdate(string version, string url)
+        {
+            _updateUrl = url;
+            UpdateText.Text = $"Nova versão {version} disponível";
+            UpdatePanel.IsVisible = true;
+        }
+
+        private async void UpdateButton_Click(object? sender, RoutedEventArgs e)
+        {
+            if (_downloadedFile == null)
+                await DownloadUpdate();
+            else
+                InstallUpdate();
+        }
+
+        private async Task DownloadUpdate()
+        {
+            if (string.IsNullOrWhiteSpace(_updateUrl))
+                return;
+            try
+            {
+                UpdateProgress.IsVisible = true;
+                UpdateButton.IsEnabled = false;
+                var progress = new Progress<double>(p => UpdateProgress.Text = $"{p:0}%");
+                _downloadedFile = await UpdateDownloader.DownloadAsync(_updateUrl, progress);
+                UpdateButton.Content = "Instalar Atualização";
+                UpdateButton.IsEnabled = true;
+            }
+            catch
+            {
+                UpdateButton.IsEnabled = true;
+                UpdateProgress.IsVisible = false;
+            }
+        }
+
+        private void InstallUpdate()
+        {
+            if (string.IsNullOrWhiteSpace(_downloadedFile))
+                return;
+            var psi = new ProcessStartInfo { FileName = _downloadedFile, UseShellExecute = true };
+            Process.Start(psi);
+            Environment.Exit(0);
         }
     }
 }


### PR DESCRIPTION
## Summary
- show home page by default then reuse it when returning
- show optional update prompt on the home page
- start download and switch button to install once ready
- use the same install flow in the mandatory update screen
- remove old update bar from MainWindow

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ce455cd0832a849ca736a2b2af2e