### PR TITLE
Enable global F7/F8 hotkeys

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -65,6 +65,7 @@ namespace GTDCompanion
                 var exitItem = new NativeMenuItem("Encerrar");
                 exitItem.Click += (_, __) =>
                 {
+                    GlobalHotkeyService.Unregister();
                     StatsTracker.Stop();
                     desktop.Shutdown();
                 };

--- a/Helpers/GlobalHotkeyService.cs
+++ b/Helpers/GlobalHotkeyService.cs
@@ -1,0 +1,27 @@
+using System;
+using GTDCompanion.Pages;
+
+namespace GTDCompanion.Helpers
+{
+    public static class GlobalHotkeyService
+    {
+        private static GlobalHotkey? _f7;
+        private static GlobalHotkey? _f8;
+
+        public static void Register()
+        {
+            _f7 = new GlobalHotkey(GlobalHotkey.VK_F7, () => MiraPage.ToggleOverlayGlobal());
+            _f7.Register();
+            _f8 = new GlobalHotkey(GlobalHotkey.VK_F8, () => MacroPage.Instance?.ToggleMacroExecution());
+            _f8.Register();
+        }
+
+        public static void Unregister()
+        {
+            _f7?.Dispose();
+            _f8?.Dispose();
+            _f7 = null;
+            _f8 = null;
+        }
+    }
+}

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -93,6 +93,7 @@ namespace GTDCompanion
             _homePage = new HomePage();
             MainContent.Content = _homePage;
             StartUpdateTimer();
+            GlobalHotkeyService.Register();
         }
 
         private void MenuInicio_Click(object? sender, RoutedEventArgs e)

--- a/Pages/Macro/MacroPage.axaml.cs
+++ b/Pages/Macro/MacroPage.axaml.cs
@@ -14,9 +14,9 @@ namespace GTDCompanion.Pages
 {
     public partial class MacroPage : UserControl
     {
+        public static MacroPage? Instance { get; private set; }
         private readonly List<MacroStep> macroSteps = new();
         private readonly Dictionary<int, MacroOverlay> overlays = new();
-        private GlobalHotkey? globalHotkey;
 
         public MacroPage()
         {
@@ -35,19 +35,19 @@ namespace GTDCompanion.Pages
 
             this.AttachedToVisualTree += (_, _) =>
             {
+                Instance = this;
                 var win = GetWindow();
                 if (win != null)
                     win.KeyDown += OnWindowKeyDown;
-                globalHotkey = new GlobalHotkey(GlobalHotkey.VK_F8, () => ExecuteMacro(null, new Avalonia.Interactivity.RoutedEventArgs()));
-                globalHotkey.Register();
             };
 
             this.DetachedFromVisualTree += (_, _) =>
             {
+                if (Instance == this)
+                    Instance = null;
                 var win = GetWindow();
                 if (win != null)
                     win.KeyDown -= OnWindowKeyDown;
-                globalHotkey?.Dispose();
             };
         }
 
@@ -228,7 +228,7 @@ namespace GTDCompanion.Pages
         private CancellationTokenSource? macroCts;
         private bool isRunning = false;
 
-        private async void ExecuteMacro(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        public async void ExecuteMacro(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             if (isRunning)
             {
@@ -319,8 +319,13 @@ namespace GTDCompanion.Pages
         {
             if (e.Key == Key.F8)
             {
-                ExecuteMacro(null, new Avalonia.Interactivity.RoutedEventArgs());
+                ToggleMacroExecution();
             }
+        }
+
+        public void ToggleMacroExecution()
+        {
+            ExecuteMacro(null, new Avalonia.Interactivity.RoutedEventArgs());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `GlobalHotkeyService` to manage F7/F8
- register hotkeys from `MainWindow`
- toggle overlay and macro execution globally
- clean up page-level hotkey handling

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845db56ba7c832a8cf771da6dece164