### PR TITLE
fix KeyboardMouseStats realtime saving and key release tracking

### DIFF
--- a/Helpers/StatsTracker.cs
+++ b/Helpers/StatsTracker.cs
@@ -182,8 +182,8 @@ namespace GTDCompanion.Helpers
 
         private static IntPtr KeyboardHookCallback(int nCode, IntPtr wParam, IntPtr lParam)
         {
-            const int WM_KEYDOWN = 0x0100;
-            if (nCode >= 0 && wParam == (IntPtr)WM_KEYDOWN)
+            const int WM_KEYUP = 0x0101;
+            if (nCode >= 0 && wParam == (IntPtr)WM_KEYUP)
             {
                 var info = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
                 Stats.KeyPresses++;
@@ -191,6 +191,7 @@ namespace GTDCompanion.Helpers
                     Stats.KeyCounts[info.vkCode] = 0;
                 Stats.KeyCounts[info.vkCode]++;
                 IncrementDailyKeyPresses();
+                Save();
                 StatsUpdated?.Invoke();
             }
             return CallNextHookEx(_keyboardHook, nCode, wParam, lParam);
@@ -232,6 +233,7 @@ namespace GTDCompanion.Helpers
                         _lastMouseMove = DateTime.Now;
                         break;
                 }
+                Save();
                 StatsUpdated?.Invoke();
             }
             return CallNextHookEx(_mouseHook, nCode, wParam, lParam);


### PR DESCRIPTION
## Summary
- save keyboard and mouse statistics immediately when they change
- count key presses on key release instead of key down to avoid repeats

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68460d69419c832a96d0a763d333adef