### PR TITLE
Implement real-time statistics update and key release counting

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -1,3 +1,6 @@
+Build 0.4.104 - Save stats in real time
+save keyboard and mouse stats to file after each event
+
 Build 0.4.103 - Improve update download flow
 show home page by default then reuse it when returning
 show optional update prompt on the home page


### PR DESCRIPTION
## Summary
- update changelog
- count keyboard presses on key release instead of repeats
- save keyboard/mouse statistics every time values change

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460f2ca638832a92d74ee794abd50c