### PR TITLE
Add Experience settings menu with start minimized option

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -88,6 +88,9 @@
             <MenuItem Header="WTF?!">
                 <MenuItem Header="Estatísticas Teclado/Mouse" Click="KeyboardMouseStatsPage_Click"/>
             </MenuItem>
+            <MenuItem Header="Configurações">
+                <MenuItem Header="Experiência" Click="ExperiencePage_Click"/>
+            </MenuItem>
             <MenuItem Header="Links">
                 <MenuItem Header="Acessar Discord" Click="AcessarDiscord_Click"/>
                 <MenuItem Header="A GTD" Click="MenuSobre_Click"/>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -94,6 +94,9 @@ namespace GTDCompanion
             MainContent.Content = _homePage;
             StartUpdateTimer();
             GlobalHotkeyService.Register();
+
+            if (GTDConfigHelper.GetBool("Experience", "StartMinimized", true))
+                this.Hide();
         }
 
         private void MenuInicio_Click(object? sender, RoutedEventArgs e)
@@ -131,6 +134,11 @@ namespace GTDCompanion
         private void MacroPage_Click(object? sender, RoutedEventArgs e)
         {
             MainContent.Content = new MacroPage();
+        }
+
+        private void ExperiencePage_Click(object? sender, RoutedEventArgs e)
+        {
+            MainContent.Content = new ExperiencePage();
         }
 
         private void KeyboardMouseStatsPage_Click(object? sender, RoutedEventArgs e)

--- a/Pages/Experience/ExperiencePage.axaml
+++ b/Pages/Experience/ExperiencePage.axaml
@@ -1,0 +1,14 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GTDCompanion.Pages.ExperiencePage"
+             Background="#23272A">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="20" Spacing="12">
+            <TextBlock Text="Experiência" FontSize="24" Foreground="#FE6A0A" FontWeight="Bold"/>
+            <StackPanel>
+                <TextBlock Text="Comportamento do Aplicativo" FontSize="18" Foreground="White" Margin="0,8,0,4"/>
+                <CheckBox x:Name="StartMinimizedBox" Content="Inicializar Minimizado com o Windows" IsChecked="True"/>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/Pages/Experience/ExperiencePage.axaml.cs
+++ b/Pages/Experience/ExperiencePage.axaml.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace GTDCompanion.Pages
+{
+    public partial class ExperiencePage : UserControl
+    {
+        public ExperiencePage()
+        {
+            InitializeComponent();
+            StartMinimizedBox.IsChecked = GTDConfigHelper.GetBool("Experience", "StartMinimized", true);
+            StartMinimizedBox.Checked += OnStartMinimizedChanged;
+            StartMinimizedBox.Unchecked += OnStartMinimizedChanged;
+        }
+
+        private void OnStartMinimizedChanged(object? sender, RoutedEventArgs e)
+        {
+            var isChecked = StartMinimizedBox.IsChecked ?? false;
+            GTDConfigHelper.Set("Experience", "StartMinimized", isChecked ? "true" : "false");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Experience settings page with scroll and a Start Minimimized option
- hook up new menu under Configurações
- hide main window on startup if the option is enabled

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846dcb7856c832a96aafb59987fdff6