### PR TITLE
Fix start minimized behaviour

### DIFF
--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Diagnostics;
 using System;
 using GTDCompanion.Helpers;
+using System.Linq;
 
 namespace GTDCompanion
 {
@@ -95,8 +96,11 @@ namespace GTDCompanion
             StartUpdateTimer();
             GlobalHotkeyService.Register();
 
-            if (GTDConfigHelper.GetBool("Behavior", "StartMinimized", true))
+            if (Environment.GetCommandLineArgs().Any(a =>
+                a.Equals("minimized", StringComparison.OrdinalIgnoreCase)))
+            {
                 this.Hide();
+            }
         }
 
         private void MenuInicio_Click(object? sender, RoutedEventArgs e)

--- a/Pages/Experience/SettingsPage.axaml.cs
+++ b/Pages/Experience/SettingsPage.axaml.cs
@@ -1,5 +1,8 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Microsoft.Win32;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace GTDCompanion.Pages
 {
@@ -8,15 +11,51 @@ namespace GTDCompanion.Pages
         public SettingsPage()
         {
             InitializeComponent();
-            StartMinimizedBox.IsChecked = GTDConfigHelper.GetBool("Behavior", "StartMinimized", true);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                StartMinimizedBox.IsChecked = IsStartupEnabled();
+            }
+            else
+            {
+                StartMinimizedBox.IsChecked = false;
+                StartMinimizedBox.IsEnabled = false;
+            }
+
             StartMinimizedBox.Checked += OnStartMinimizedChanged;
             StartMinimizedBox.Unchecked += OnStartMinimizedChanged;
         }
 
         private void OnStartMinimizedChanged(object? sender, RoutedEventArgs e)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
             var isChecked = StartMinimizedBox.IsChecked ?? false;
-            GTDConfigHelper.Set("Behavior", "StartMinimized", isChecked ? "true" : "false");
+            using var key = Registry.CurrentUser.OpenSubKey(
+                "Software\\Microsoft\\Windows\\CurrentVersion\\Run", writable: true);
+            if (key == null)
+                return;
+
+            if (isChecked)
+            {
+                var exePath = Process.GetCurrentProcess().MainModule?.FileName ?? string.Empty;
+                key.SetValue("GTDCompanion", $"\"{exePath}\" minimized");
+            }
+            else
+            {
+                key.DeleteValue("GTDCompanion", false);
+            }
+        }
+
+        private static bool IsStartupEnabled()
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(
+                "Software\\Microsoft\\Windows\\CurrentVersion\\Run", writable: false);
+            if (key == null)
+                return false;
+            var value = key.GetValue("GTDCompanion") as string;
+            return !string.IsNullOrWhiteSpace(value);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure SettingsPage startup toggle adds/removes Run registry entry
- only hide window at startup when invoked with the "minimized" argument

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846e14127dc832ab63c396cf7a56e8e