### PR TITLE
Fix GPU monitor when IDProcess is missing

### DIFF
--- a/Helpers/GpuProcessMonitor.cs
+++ b/Helpers/GpuProcessMonitor.cs
@@ -117,10 +117,11 @@ namespace GTDCompanion.Helpers
 
                 foreach (ManagementObject obj in searcher.Get())
                 {
-                    if (obj["IDProcess"] == null)
+                    var idProp = obj.Properties["IDProcess"];
+                    if (idProp == null || idProp.Value == null)
                         continue;
 
-                    if (!int.TryParse(obj["IDProcess"].ToString(), out int pid))
+                    if (!int.TryParse(idProp.Value.ToString(), out int pid))
                         continue;
 
                     double pct = 0;


### PR DESCRIPTION
## Summary
- avoid `ManagementException` if `IDProcess` property doesn't exist

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847056ef6c8832aaa82c049579c3e92