### PR TITLE
Add Ajuda menu and about page

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -96,6 +96,9 @@
                 <MenuItem Header="A GTD" Click="MenuSobre_Click"/>
                 <MenuItem Header="Suporte" Click="MenuSuporte_Click"/>
             </MenuItem>
+            <MenuItem Header="Ajuda">
+                <MenuItem Header="Sobre" Click="MenuAjudaSobre_Click"/>
+            </MenuItem>
         </Menu>
         <!-- Conteúdo central dinâmico -->
         <ContentControl x:Name="MainContent" Margin="0,1,0,0"/>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -186,6 +186,11 @@ namespace GTDCompanion
             Process.Start(psi);
         }
 
+        private void MenuAjudaSobre_Click(object? sender, RoutedEventArgs e)
+        {
+            MainContent.Content = new AboutPage();
+        }
+
 
         private void StartUpdateTimer()
         {

--- a/Pages/Help/AboutPage.axaml
+++ b/Pages/Help/AboutPage.axaml
@@ -1,0 +1,22 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="GTDCompanion.Pages.AboutPage"
+             Background="#2C2F33">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="20" Spacing="12">
+            <Image Source="avares://GTDCompanion/Assets/logo.png"
+                   Width="120" HorizontalAlignment="Center"/>
+            <TextBlock Text="Sobre o GTD Companion" FontSize="24" FontWeight="Bold" Foreground="#FE6A0A" HorizontalAlignment="Center" Margin="0,10"/>
+            <TextBlock TextWrapping="Wrap" Foreground="White">
+                A Comunidade GTD (Game Try Division) é um grupo de entusiastas focados em integrar ferramentas,
+                overlays e automações que melhoram a experiência gamer. O GTD Companion reúne diversas dessas
+                funcionalidades em um único aplicativo para tornar sua vida mais simples.
+            </TextBlock>
+            <TextBlock TextWrapping="Wrap" Foreground="White">
+                Este projeto é mantido coletivamente pela comunidade e está em constante evolução. Fique à vontade
+                para participar do nosso Discord e colaborar com ideias, feedbacks e testes.
+            </TextBlock>
+            <TextBlock x:Name="VersionText" HorizontalAlignment="Center" Margin="0,20,0,0" Foreground="#AAAAAA"/>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/Pages/Help/AboutPage.axaml.cs
+++ b/Pages/Help/AboutPage.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+using System.Diagnostics;
+
+namespace GTDCompanion.Pages
+{
+    public partial class AboutPage : UserControl
+    {
+        public AboutPage()
+        {
+            InitializeComponent();
+
+            var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+            if (!string.IsNullOrWhiteSpace(exePath))
+            {
+                var version = FileVersionInfo.GetVersionInfo(exePath).FileVersion;
+                VersionText.Text = $"Versão {version}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new main menu `Ajuda` with `Sobre`
- implement `AboutPage` showing GTD Companion info and version
- load the page when the new menu option is clicked

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471182d910832ab61952e94aeee7b1