### PR TITLE
Adjust stats tracking to rely solely on json

### DIFF
--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="GTDCompanion.Pages.KeyboardMouseStatsPage"
              Background="#2C2F33">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
     <StackPanel Margin="10" Spacing="8">
         <TextBlock Text="Estatísticas de Teclado/Mouse" FontSize="20" FontWeight="Bold" Foreground="#FE6A0A" HorizontalAlignment="Center"/>
         <Grid ColumnDefinitions="*,*" ColumnSpacing="20">
@@ -33,4 +34,5 @@
             <Button Content="Resetar manutenção" Click="ResetMaintenance_Click"/>
         </StackPanel>
     </StackPanel>
+    </ScrollViewer>
 </UserControl>

--- a/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
+++ b/Pages/Wtf/KeyboardMouseStatsPage.axaml.cs
@@ -70,11 +70,25 @@ namespace GTDCompanion.Pages
             TopKeysText.Text = "Top 3 teclas: " + string.Join(", ", top3);
 
             TimeSpan up = DateTime.Now - StatsTracker.StartTime;
-            UptimeText.Text = $"Tempo de atividade: {up:dd\\:hh\\:mm\\:ss}";
-            IdleText.Text = $"Tempo ocioso: {s.IdleTime:dd\\:hh\\:mm}";
-            ActiveTimeText.Text = $"Tempo de atividade geral: {s.ActiveTime:dd\\:hh\\:mm}";
+            UptimeText.Text = $"Tempo de atividade: {FormatTimeSpan(up)}";
+            IdleText.Text = $"Tempo ocioso: {FormatTimeSpan(s.IdleTime)}";
+            ActiveTimeText.Text = $"Ativo geral: {FormatTimeSpan(s.ActiveTime)}";
             TimeSpan sinceMaint = DateTime.Now - s.LastMaintenance;
-            MaintenanceText.Text = $"Desde manutenção: {sinceMaint:dd\\:hh\\:mm}";
+            MaintenanceText.Text = $"Desde manutenção: {FormatTimeSpan(sinceMaint)}";
+        }
+
+        private static string FormatTimeSpan(TimeSpan ts)
+        {
+            var parts = new System.Collections.Generic.List<string>();
+            if (ts.Days > 0)
+                parts.Add($"{ts.Days}d");
+            if (ts.Hours > 0)
+                parts.Add($"{ts.Hours}h");
+            if (ts.Minutes > 0)
+                parts.Add($"{ts.Minutes}m");
+            if (parts.Count == 0 || ts.Seconds > 0)
+                parts.Add($"{ts.Seconds}s");
+            return string.Join(" ", parts);
         }
 
         private void ResetMaintenance_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- avoid in-memory stats cache and load data from json file for every update
- present time values in a modern format and make stats page scrollable

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fbc613fc832aaa7d95df688df071