### PR TITLE
Add localization system with OS language detection

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -26,6 +26,7 @@ namespace GTDCompanion
         {
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
+                LocalizationManager.LoadCulture(null);
                 desktop.ShutdownMode = Avalonia.Controls.ShutdownMode.OnExplicitShutdown;
                 desktop.MainWindow = new MainWindow();
                 desktop.MainWindow.Closed += (_, __) =>

--- a/GTDCompanion.csproj
+++ b/GTDCompanion.csproj
@@ -42,6 +42,7 @@
     <AvaloniaResource Include="Assets\logo.png" />
     <AvaloniaResource Include="Assets\icon.ico" />
     <EmbeddedResource Include="AppConfig.json" />
+    <EmbeddedResource Include="Locales\*.json" />
     <AvaloniaResource Include=".changelog" />
 
     <Reference Include="RTSSSharedMemoryNET">

--- a/Locales/en-US.json
+++ b/Locales/en-US.json
@@ -1,0 +1,20 @@
+{
+  "menu_home": "Home",
+  "menu_features": "Features",
+  "menu_setup": "My Setup",
+  "menu_benchmark": "Benchmark",
+  "menu_mira_overlay": "Crosshair Overlay",
+  "menu_translator_overlay": "AI Translator Overlay",
+  "menu_sticker_notes": "Sticker Notes",
+  "menu_macro_experience": "Macro Experience",
+  "menu_wtf": "WTF?!",
+  "menu_keyboard_mouse_stats": "Keyboard/Mouse Stats",
+  "menu_experience": "Experience",
+  "menu_settings": "Settings",
+  "menu_links": "Links",
+  "menu_access_discord": "Join Discord",
+  "menu_about": "The GTD",
+  "menu_support": "Support",
+  "menu_help": "Help",
+  "menu_about_help": "About"
+}

--- a/Locales/es-ES.json
+++ b/Locales/es-ES.json
@@ -1,0 +1,20 @@
+{
+  "menu_home": "Inicio",
+  "menu_features": "Funcionalidades",
+  "menu_setup": "Mi Equipo",
+  "menu_benchmark": "Benchmark",
+  "menu_mira_overlay": "Mira Overlay",
+  "menu_translator_overlay": "Overlay Traductor IA",
+  "menu_sticker_notes": "Sticker Notes",
+  "menu_macro_experience": "Macro Experience",
+  "menu_wtf": "WTF?!",
+  "menu_keyboard_mouse_stats": "Estadísticas Teclado/Mouse",
+  "menu_experience": "Experiencia",
+  "menu_settings": "Configuraciones",
+  "menu_links": "Enlaces",
+  "menu_access_discord": "Acceder a Discord",
+  "menu_about": "La GTD",
+  "menu_support": "Soporte",
+  "menu_help": "Ayuda",
+  "menu_about_help": "Acerca de"
+}

--- a/Locales/it-IT.json
+++ b/Locales/it-IT.json
@@ -1,0 +1,20 @@
+{
+  "menu_home": "Inizio",
+  "menu_features": "Funzionalità",
+  "menu_setup": "Il Mio Setup",
+  "menu_benchmark": "Benchmark",
+  "menu_mira_overlay": "Mira Overlay",
+  "menu_translator_overlay": "Overlay Traduttore IA",
+  "menu_sticker_notes": "Sticker Notes",
+  "menu_macro_experience": "Macro Experience",
+  "menu_wtf": "WTF?!",
+  "menu_keyboard_mouse_stats": "Statistiche Tastiera/Mouse",
+  "menu_experience": "Esperienza",
+  "menu_settings": "Impostazioni",
+  "menu_links": "Link",
+  "menu_access_discord": "Accedi a Discord",
+  "menu_about": "La GTD",
+  "menu_support": "Supporto",
+  "menu_help": "Aiuto",
+  "menu_about_help": "Informazioni"
+}

--- a/Locales/pt-BR.json
+++ b/Locales/pt-BR.json
@@ -1,0 +1,20 @@
+{
+  "menu_home": "Início",
+  "menu_features": "Funcionalidades",
+  "menu_setup": "Meu Setup",
+  "menu_benchmark": "Benchmark",
+  "menu_mira_overlay": "Mira Overlay",
+  "menu_translator_overlay": "Tradução IA Overlay",
+  "menu_sticker_notes": "Sticker Notes",
+  "menu_macro_experience": "Macro Experience",
+  "menu_wtf": "WTF?!",
+  "menu_keyboard_mouse_stats": "Estatísticas Teclado/Mouse",
+  "menu_experience": "Experiência",
+  "menu_settings": "Configurações",
+  "menu_links": "Links",
+  "menu_access_discord": "Acessar Discord",
+  "menu_about": "A GTD",
+  "menu_support": "Suporte",
+  "menu_help": "Ajuda",
+  "menu_about_help": "Sobre"
+}

--- a/LocalizationManager.cs
+++ b/LocalizationManager.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+
+namespace GTDCompanion
+{
+    public static class LocalizationManager
+    {
+        private static readonly Dictionary<string, string> _strings = new();
+        private const string DefaultCulture = "pt-BR";
+
+        static LocalizationManager()
+        {
+            LoadCulture(null);
+        }
+
+        public static void LoadCulture(string? cultureName)
+        {
+            if (string.IsNullOrWhiteSpace(cultureName))
+                cultureName = CultureInfo.InstalledUICulture.Name;
+
+            var asm = Assembly.GetExecutingAssembly();
+            var candidates = new List<string>
+            {
+                $"GTDCompanion.Locales.{cultureName}.json",
+                $"GTDCompanion.Locales.{cultureName.Split('-')[0]}.json",
+                $"GTDCompanion.Locales.{DefaultCulture}.json"
+            };
+
+            foreach (var resource in candidates)
+            {
+                using Stream? s = asm.GetManifestResourceStream(resource);
+                if (s != null)
+                {
+                    using var reader = new StreamReader(s);
+                    var json = reader.ReadToEnd();
+                    var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+                    if (data != null)
+                    {
+                        _strings.Clear();
+                        foreach (var kv in data)
+                            _strings[kv.Key] = kv.Value;
+                        return;
+                    }
+                }
+            }
+        }
+
+        public static string Get(string key)
+        {
+            return _strings.TryGetValue(key, out var value) ? value : key;
+        }
+    }
+}

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -76,28 +76,28 @@
         </Border>
         <!-- Menu superior -->
         <Menu x:Name="MainMenuBox" DockPanel.Dock="Top" Background="#36393F" Foreground="White" >
-            <MenuItem Header="Início" Click="MenuInicio_Click"/>
-            <MenuItem Header="Funcionalidades">
-                <MenuItem Header="Meu Setup" Click="CheckMySetup_Page"/>
-                <MenuItem Header="Benchmark" Click="BenchmarkOverlayPage_Click"/>
-                <MenuItem Header="Mira Overlay" Click="MenuMira_Click"/>
-                <MenuItem Header="Tradução IA Overlay" Click="TranslatorOverlay_Click"/>
-                <MenuItem Header="Sticker Notes" Click="StickerNotesPage_Click"/>
-                <MenuItem Header="Macro Experience" Click="MacroPage_Click"/>
-            </MenuItem>            
-            <MenuItem Header="WTF?!">
-                <MenuItem Header="Estatísticas Teclado/Mouse" Click="KeyboardMouseStatsPage_Click"/>
+            <MenuItem x:Name="MenuInicio" Header="Início" Click="MenuInicio_Click"/>
+            <MenuItem x:Name="MenuFuncionalidades" Header="Funcionalidades">
+                <MenuItem x:Name="MenuMeuSetup" Header="Meu Setup" Click="CheckMySetup_Page"/>
+                <MenuItem x:Name="MenuBenchmark" Header="Benchmark" Click="BenchmarkOverlayPage_Click"/>
+                <MenuItem x:Name="MenuMiraOverlay" Header="Mira Overlay" Click="MenuMira_Click"/>
+                <MenuItem x:Name="MenuTranslatorOverlay" Header="Tradução IA Overlay" Click="TranslatorOverlay_Click"/>
+                <MenuItem x:Name="MenuStickerNotes" Header="Sticker Notes" Click="StickerNotesPage_Click"/>
+                <MenuItem x:Name="MenuMacroExperience" Header="Macro Experience" Click="MacroPage_Click"/>
             </MenuItem>
-            <MenuItem Header="Experiência">
-                <MenuItem Header="Configurações" Click="SetingsPago_Click"/>
+            <MenuItem x:Name="MenuWtf" Header="WTF?!">
+                <MenuItem x:Name="MenuKeyboardMouseStats" Header="Estatísticas Teclado/Mouse" Click="KeyboardMouseStatsPage_Click"/>
             </MenuItem>
-            <MenuItem Header="Links">
-                <MenuItem Header="Acessar Discord" Click="AcessarDiscord_Click"/>
-                <MenuItem Header="A GTD" Click="MenuSobre_Click"/>
-                <MenuItem Header="Suporte" Click="MenuSuporte_Click"/>
+            <MenuItem x:Name="MenuExperience" Header="Experiência">
+                <MenuItem x:Name="MenuSettings" Header="Configurações" Click="SetingsPago_Click"/>
             </MenuItem>
-            <MenuItem Header="Ajuda">
-                <MenuItem Header="Sobre" Click="MenuAjudaSobre_Click"/>
+            <MenuItem x:Name="MenuLinks" Header="Links">
+                <MenuItem x:Name="MenuDiscord" Header="Acessar Discord" Click="AcessarDiscord_Click"/>
+                <MenuItem x:Name="MenuAGTD" Header="A GTD" Click="MenuSobre_Click"/>
+                <MenuItem x:Name="MenuSupport" Header="Suporte" Click="MenuSuporte_Click"/>
+            </MenuItem>
+            <MenuItem x:Name="MenuAjuda" Header="Ajuda">
+                <MenuItem x:Name="MenuAjudaSobre" Header="Sobre" Click="MenuAjudaSobre_Click"/>
             </MenuItem>
         </Menu>
         <!-- Conteúdo central dinâmico -->

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -24,6 +24,9 @@ namespace GTDCompanion
         {
             InitializeComponent();
 
+            // Aplica traduções no menu
+            SetMenuTranslations();
+
             // Custom barra de título: eventos de arrastar, minimizar, fechar
             var customTitleBar = this.FindControl<Border>("CustomTitleBar");
             var closeBtn = this.FindControl<Button>("CloseButton");
@@ -189,6 +192,28 @@ namespace GTDCompanion
         private void MenuAjudaSobre_Click(object? sender, RoutedEventArgs e)
         {
             MainContent.Content = new AboutPage();
+        }
+
+        private void SetMenuTranslations()
+        {
+            this.FindControl<MenuItem>("MenuInicio").Header = LocalizationManager.Get("menu_home");
+            this.FindControl<MenuItem>("MenuFuncionalidades").Header = LocalizationManager.Get("menu_features");
+            this.FindControl<MenuItem>("MenuMeuSetup").Header = LocalizationManager.Get("menu_setup");
+            this.FindControl<MenuItem>("MenuBenchmark").Header = LocalizationManager.Get("menu_benchmark");
+            this.FindControl<MenuItem>("MenuMiraOverlay").Header = LocalizationManager.Get("menu_mira_overlay");
+            this.FindControl<MenuItem>("MenuTranslatorOverlay").Header = LocalizationManager.Get("menu_translator_overlay");
+            this.FindControl<MenuItem>("MenuStickerNotes").Header = LocalizationManager.Get("menu_sticker_notes");
+            this.FindControl<MenuItem>("MenuMacroExperience").Header = LocalizationManager.Get("menu_macro_experience");
+            this.FindControl<MenuItem>("MenuWtf").Header = LocalizationManager.Get("menu_wtf");
+            this.FindControl<MenuItem>("MenuKeyboardMouseStats").Header = LocalizationManager.Get("menu_keyboard_mouse_stats");
+            this.FindControl<MenuItem>("MenuExperience").Header = LocalizationManager.Get("menu_experience");
+            this.FindControl<MenuItem>("MenuSettings").Header = LocalizationManager.Get("menu_settings");
+            this.FindControl<MenuItem>("MenuLinks").Header = LocalizationManager.Get("menu_links");
+            this.FindControl<MenuItem>("MenuDiscord").Header = LocalizationManager.Get("menu_access_discord");
+            this.FindControl<MenuItem>("MenuAGTD").Header = LocalizationManager.Get("menu_about");
+            this.FindControl<MenuItem>("MenuSupport").Header = LocalizationManager.Get("menu_support");
+            this.FindControl<MenuItem>("MenuAjuda").Header = LocalizationManager.Get("menu_help");
+            this.FindControl<MenuItem>("MenuAjudaSobre").Header = LocalizationManager.Get("menu_about_help");
         }
 
 


### PR DESCRIPTION
## Summary
- implement `LocalizationManager` to load language files embedded in the assembly
- embed JSON language files (pt-BR default, plus en-US, it-IT and es-ES)
- load localization on startup and apply translations to main menu
- update project file to include JSON resources

## Testing
- `dotnet build -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480108afb0832abf3bc7d14980aa25