### PR TITLE
Add basic localization support

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -41,6 +41,8 @@ namespace GTDCompanion
                 StatsTracker.Start();
 
                 AppConfig.PopulateEnvironment();
+                var lang = GTDConfigHelper.GetString("General", "language", "pt-BR");
+                LocalizationManager.SetCulture(lang);
 
 
 

--- a/GTDCompanion.csproj
+++ b/GTDCompanion.csproj
@@ -42,6 +42,10 @@
     <AvaloniaResource Include="Assets\logo.png" />
     <AvaloniaResource Include="Assets\icon.ico" />
     <EmbeddedResource Include="AppConfig.json" />
+    <EmbeddedResource Include="Resources\Resources.resx" />
+    <EmbeddedResource Include="Resources\Resources.en-US.resx" />
+    <EmbeddedResource Include="Resources\Resources.es-ES.resx" />
+    <EmbeddedResource Include="Resources\Resources.it-IT.resx" />
     <AvaloniaResource Include=".changelog" />
 
     <Reference Include="RTSSSharedMemoryNET">

--- a/Helpers/LocalizationManager.cs
+++ b/Helpers/LocalizationManager.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Resources;
+using Avalonia.Data;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+
+namespace GTDCompanion.Helpers
+{
+    public static class LocalizationManager
+    {
+        private static CultureInfo _culture = new("pt-BR");
+        private static readonly ResourceManager _rm = new("GTDCompanion.Resources", Assembly.GetExecutingAssembly());
+
+        public static event Action? LanguageChanged;
+
+        public static CultureInfo CurrentCulture
+        {
+            get => _culture;
+        }
+
+        public static void SetCulture(string name)
+        {
+            try
+            {
+                _culture = new CultureInfo(name);
+            }
+            catch
+            {
+                _culture = new CultureInfo("pt-BR");
+            }
+            LanguageChanged?.Invoke();
+        }
+
+        public static string Translate(string key, string? defaultValue = null)
+        {
+            var value = _rm.GetString(key, _culture);
+            return string.IsNullOrEmpty(value) ? defaultValue ?? key : value;
+        }
+    }
+
+    public class LocalizedBinding : IBinding, IDisposable
+    {
+        private readonly string _key;
+        private readonly string? _default;
+        private event Action? _valueChanged;
+        public LocalizedBinding(string key, string? def)
+        {
+            _key = key;
+            _default = def;
+            LocalizationManager.LanguageChanged += OnChanged;
+        }
+        public InstancedBinding? Initiate(Avalonia.AvaloniaObject target, Avalonia.AvaloniaProperty property, object? anchor, bool enableDataValidation)
+        {
+            return InstancedBinding.OneWay(GetValue(), _ => { _valueChanged = _; });
+        }
+        private object GetValue() => LocalizationManager.Translate(_key, _default);
+        private void OnChanged() => _valueChanged?.Invoke();
+        public void Dispose() => LocalizationManager.LanguageChanged -= OnChanged;
+    }
+
+    public class TrExtension : MarkupExtension
+    {
+        public string Key { get; set; } = string.Empty;
+        public string? Default { get; set; }
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return new LocalizedBinding(Key, Default);
+        }
+    }
+}

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="clr-namespace:GTDCompanion"
     xmlns:pages="clr-namespace:GTDCompanion.Pages"
+    xmlns:l="clr-namespace:GTDCompanion.Helpers"
     x:Class="GTDCompanion.MainWindow"
     Title="GTD Companion"
     Icon="avares://GTDCompanion/Assets/icon.ico"
@@ -76,28 +77,28 @@
         </Border>
         <!-- Menu superior -->
         <Menu x:Name="MainMenuBox" DockPanel.Dock="Top" Background="#36393F" Foreground="White" >
-            <MenuItem Header="Início" Click="MenuInicio_Click"/>
-            <MenuItem Header="Funcionalidades">
-                <MenuItem Header="Meu Setup" Click="CheckMySetup_Page"/>
-                <MenuItem Header="Benchmark" Click="BenchmarkOverlayPage_Click"/>
-                <MenuItem Header="Mira Overlay" Click="MenuMira_Click"/>
-                <MenuItem Header="Tradução IA Overlay" Click="TranslatorOverlay_Click"/>
-                <MenuItem Header="Sticker Notes" Click="StickerNotesPage_Click"/>
-                <MenuItem Header="Macro Experience" Click="MacroPage_Click"/>
-            </MenuItem>            
-            <MenuItem Header="WTF?!">
-                <MenuItem Header="Estatísticas Teclado/Mouse" Click="KeyboardMouseStatsPage_Click"/>
+            <MenuItem Header="{l:Tr Menu_Home, Default='Início'}" Click="MenuInicio_Click"/>
+            <MenuItem Header="{l:Tr Menu_Features, Default='Funcionalidades'}">
+                <MenuItem Header="{l:Tr Menu_MySetup, Default='Meu Setup'}" Click="CheckMySetup_Page"/>
+                <MenuItem Header="{l:Tr Menu_Benchmark, Default='Benchmark'}" Click="BenchmarkOverlayPage_Click"/>
+                <MenuItem Header="{l:Tr Menu_Crosshair, Default='Mira Overlay'}" Click="MenuMira_Click"/>
+                <MenuItem Header="{l:Tr Menu_Translator, Default='Tradução IA Overlay'}" Click="TranslatorOverlay_Click"/>
+                <MenuItem Header="{l:Tr Menu_Notes, Default='Sticker Notes'}" Click="StickerNotesPage_Click"/>
+                <MenuItem Header="{l:Tr Menu_Macro, Default='Macro Experience'}" Click="MacroPage_Click"/>
             </MenuItem>
-            <MenuItem Header="Experiência">
-                <MenuItem Header="Configurações" Click="SetingsPago_Click"/>
+            <MenuItem Header="{l:Tr Menu_WTF, Default='WTF?!'}">
+                <MenuItem Header="{l:Tr Menu_KbmStats, Default='Estatísticas Teclado/Mouse'}" Click="KeyboardMouseStatsPage_Click"/>
             </MenuItem>
-            <MenuItem Header="Links">
-                <MenuItem Header="Acessar Discord" Click="AcessarDiscord_Click"/>
-                <MenuItem Header="A GTD" Click="MenuSobre_Click"/>
-                <MenuItem Header="Suporte" Click="MenuSuporte_Click"/>
+            <MenuItem Header="{l:Tr Menu_Experience, Default='Experiência'}">
+                <MenuItem Header="{l:Tr Menu_Settings, Default='Configurações'}" Click="SetingsPago_Click"/>
             </MenuItem>
-            <MenuItem Header="Ajuda">
-                <MenuItem Header="Sobre" Click="MenuAjudaSobre_Click"/>
+            <MenuItem Header="{l:Tr Menu_Links, Default='Links'}">
+                <MenuItem Header="{l:Tr Menu_Discord, Default='Acessar Discord'}" Click="AcessarDiscord_Click"/>
+                <MenuItem Header="{l:Tr Menu_GTD, Default='A GTD'}" Click="MenuSobre_Click"/>
+                <MenuItem Header="{l:Tr Menu_Support, Default='Suporte'}" Click="MenuSuporte_Click"/>
+            </MenuItem>
+            <MenuItem Header="{l:Tr Menu_Help, Default='Ajuda'}">
+                <MenuItem Header="{l:Tr Menu_About, Default='Sobre'}" Click="MenuAjudaSobre_Click"/>
             </MenuItem>
         </Menu>
         <!-- Conteúdo central dinâmico -->

--- a/Pages/Experience/SettingsPage.axaml
+++ b/Pages/Experience/SettingsPage.axaml
@@ -1,13 +1,23 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:l="clr-namespace:GTDCompanion.Helpers"
              x:Class="GTDCompanion.Pages.SettingsPage"
              Background="#23272A">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="20" Spacing="12">
-            <TextBlock Text="Comportamento do GTD Companion" FontSize="24" Foreground="#FE6A0A" FontWeight="Bold"/>
+            <TextBlock Text="{l:Tr Settings_Title, Default='Comportamento do GTD Companion'}" FontSize="24" Foreground="#FE6A0A" FontWeight="Bold"/>
             <StackPanel>
-                <TextBlock Text="Comportamento do Aplicativo" FontSize="18" Foreground="White" Margin="0,8,0,4"/>
-                <CheckBox x:Name="StartMinimizedBox" Content="Inicializar Minimizado com o Windows" IsChecked="True"/>
+                <TextBlock Text="{l:Tr Settings_AppBehavior, Default='Comportamento do Aplicativo'}" FontSize="18" Foreground="White" Margin="0,8,0,4"/>
+                <CheckBox x:Name="StartMinimizedBox" Content="{l:Tr Settings_StartMinimized, Default='Inicializar Minimizado com o Windows'}" IsChecked="True"/>
+            </StackPanel>
+            <StackPanel Margin="0,8,0,0">
+                <TextBlock Text="{l:Tr Settings_Language, Default='Idioma'}" FontSize="18" Foreground="White" Margin="0,8,0,4"/>
+                <ComboBox x:Name="LangCombo" Width="200">
+                    <ComboBoxItem Content="Português (Brasil)" Tag="pt-BR"/>
+                    <ComboBoxItem Content="English" Tag="en-US"/>
+                    <ComboBoxItem Content="Español" Tag="es-ES"/>
+                    <ComboBoxItem Content="Italiano" Tag="it-IT"/>
+                </ComboBox>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/Pages/Experience/SettingsPage.axaml.cs
+++ b/Pages/Experience/SettingsPage.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Interactivity;
 using Microsoft.Win32;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using GTDCompanion.Helpers;
 
 namespace GTDCompanion.Pages
 {
@@ -23,6 +24,14 @@ namespace GTDCompanion.Pages
             }
 
             StartMinimizedBox.IsCheckedChanged += OnStartMinimizedChanged;
+
+            string lang = GTDConfigHelper.GetString("General", "language", "pt-BR");
+            foreach (var item in LangCombo.Items!)
+            {
+                if (item is ComboBoxItem cbi && (cbi.Tag as string) == lang)
+                    LangCombo.SelectedItem = item;
+            }
+            LangCombo.SelectionChanged += LangCombo_SelectionChanged;
         }
 
         private void OnStartMinimizedChanged(object? sender, RoutedEventArgs e)
@@ -58,6 +67,15 @@ namespace GTDCompanion.Pages
                 return false;
             var value = key.GetValue("GTDCompanion") as string;
             return !string.IsNullOrWhiteSpace(value);
+        }
+
+        private void LangCombo_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            if (LangCombo.SelectedItem is ComboBoxItem cbi && cbi.Tag is string lang)
+            {
+                GTDConfigHelper.Set("General", "language", lang);
+                LocalizationManager.SetCulture(lang);
+            }
         }
     }
 }

--- a/Pages/Help/AboutPage.axaml
+++ b/Pages/Help/AboutPage.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:l="clr-namespace:GTDCompanion.Helpers"
              x:Class="GTDCompanion.Pages.AboutPage">
     <UserControl.Background>
         <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
@@ -11,7 +12,7 @@
         <StackPanel Margin="20" Spacing="16">
             <StackPanel HorizontalAlignment="Center" Spacing="8">
                 <Image Source="avares://GTDCompanion/Assets/logo.png" Width="140"/>
-                <TextBlock Text="Sobre o GTD Companion" FontSize="28" FontWeight="Bold" Foreground="#FE6A0A" HorizontalAlignment="Center"/>
+                <TextBlock Text="{l:Tr About_Title, Default='Sobre o GTD Companion'}" FontSize="28" FontWeight="Bold" Foreground="#FE6A0A" HorizontalAlignment="Center"/>
             </StackPanel>
             <Border Background="#3A3D41" CornerRadius="10" Padding="14">
                 <StackPanel Spacing="6">

--- a/Pages/HomePage.axaml
+++ b/Pages/HomePage.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:l="clr-namespace:GTDCompanion.Helpers"
              x:Class="GTDCompanion.Pages.HomePage"
              Background="#2C2F33">
     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="18">
@@ -10,8 +11,8 @@
                HorizontalAlignment="Center"
                Margin="0,0,0,8"/>
         <TextBlock Text="GTD Companion" FontSize="30" Foreground="#FE6A0A" FontWeight="Bold" HorizontalAlignment="Center"/>
-        <TextBlock Text="Sua central gamer para overlays, automações e integrações." FontSize="20" Foreground="White" HorizontalAlignment="Center"/>
-        <TextBlock Text="Selecione uma funcionalidade no menu acima para começar." FontSize="16" Foreground="#cccccc" HorizontalAlignment="Center"/>
+        <TextBlock Text="{l:Tr Home_Tagline, Default='Sua central gamer para overlays, automações e integrações.'}" FontSize="20" Foreground="White" HorizontalAlignment="Center"/>
+        <TextBlock Text="{l:Tr Home_SelectFeature, Default='Selecione uma funcionalidade no menu acima para começar.'}" FontSize="16" Foreground="#cccccc" HorizontalAlignment="Center"/>
         <TextBlock x:Name="VersionText"
                    Grid.Row="1"
                    HorizontalAlignment="Center"
@@ -22,7 +23,7 @@
                    FontWeight="Normal"/>
         <StackPanel x:Name="UpdatePanel" IsVisible="False" Spacing="4" HorizontalAlignment="Center">
             <TextBlock x:Name="UpdateText" Foreground="#ccc" FontSize="13" TextAlignment="Center"/>
-            <Button x:Name="UpdateButton" Content="Atualizar" Click="UpdateButton_Click"  HorizontalAlignment="Center"/>
+            <Button x:Name="UpdateButton" Content="{l:Tr Update_Button, Default='Atualizar'}" Click="UpdateButton_Click"  HorizontalAlignment="Center"/>
             <TextBlock x:Name="UpdateProgress" Foreground="#ccc" FontSize="13" TextAlignment="Center" IsVisible="False"/>
         </StackPanel>
     </StackPanel>

--- a/Pages/TranslatorAI/TranslatorPage.axaml
+++ b/Pages/TranslatorAI/TranslatorPage.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:l="clr-namespace:GTDCompanion.Helpers"
              x:Class="GTDCompanion.Pages.TranslatorPage">
   <Border Background="#222" CornerRadius="12" Padding="20">
     <StackPanel Spacing="12">
@@ -26,7 +27,7 @@
         <Button Name="TranslateButton" Content="Traduzir" Width="90"/>
       </StackPanel>
       <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-        <Button Name="OpenOverlayButton" Content="Abrir Overlay de Tradução" Width="200"/>
+        <Button Name="OpenOverlayButton" Content="{l:Tr Translator_OpenOverlay, Default='Abrir Overlay de Tradução'}" Width="200"/>
       </StackPanel>
     </StackPanel>
   </Border>

--- a/Resources/Resources.en-US.resx
+++ b/Resources/Resources.en-US.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Menu_Home" xml:space="preserve"><value>Home</value></data>
+  <data name="Menu_Features" xml:space="preserve"><value>Features</value></data>
+  <data name="Menu_MySetup" xml:space="preserve"><value>My Setup</value></data>
+  <data name="Menu_Benchmark" xml:space="preserve"><value>Benchmark</value></data>
+  <data name="Menu_Crosshair" xml:space="preserve"><value>Crosshair Overlay</value></data>
+  <data name="Menu_Translator" xml:space="preserve"><value>AI Translation Overlay</value></data>
+  <data name="Menu_Notes" xml:space="preserve"><value>Sticker Notes</value></data>
+  <data name="Menu_Macro" xml:space="preserve"><value>Macro Experience</value></data>
+  <data name="Menu_WTF" xml:space="preserve"><value>WTF?!</value></data>
+  <data name="Menu_KbmStats" xml:space="preserve"><value>Keyboard/Mouse Stats</value></data>
+  <data name="Menu_Experience" xml:space="preserve"><value>Experience</value></data>
+  <data name="Menu_Settings" xml:space="preserve"><value>Settings</value></data>
+  <data name="Menu_Links" xml:space="preserve"><value>Links</value></data>
+  <data name="Menu_Discord" xml:space="preserve"><value>Join Discord</value></data>
+  <data name="Menu_GTD" xml:space="preserve"><value>About GTD</value></data>
+  <data name="Menu_Support" xml:space="preserve"><value>Support</value></data>
+  <data name="Menu_Help" xml:space="preserve"><value>Help</value></data>
+  <data name="Menu_About" xml:space="preserve"><value>About</value></data>
+  <data name="Home_Tagline" xml:space="preserve"><value>Your gamer hub for overlays, automations and integrations.</value></data>
+  <data name="Home_SelectFeature" xml:space="preserve"><value>Select a feature from the menu above to get started.</value></data>
+  <data name="Update_Button" xml:space="preserve"><value>Update</value></data>
+  <data name="Settings_Title" xml:space="preserve"><value>GTD Companion Behavior</value></data>
+  <data name="Settings_AppBehavior" xml:space="preserve"><value>Application Behavior</value></data>
+  <data name="Settings_StartMinimized" xml:space="preserve"><value>Start Minimized with Windows</value></data>
+  <data name="Settings_Language" xml:space="preserve"><value>Language</value></data>
+  <data name="About_Title" xml:space="preserve"><value>About GTD Companion</value></data>
+  <data name="Translator_OpenOverlay" xml:space="preserve"><value>Open Translation Overlay</value></data>
+</root>

--- a/Resources/Resources.es-ES.resx
+++ b/Resources/Resources.es-ES.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Menu_Home" xml:space="preserve"><value>Inicio</value></data>
+  <data name="Menu_Features" xml:space="preserve"><value>Funcionalidades</value></data>
+  <data name="Menu_MySetup" xml:space="preserve"><value>Mi Setup</value></data>
+  <data name="Menu_Benchmark" xml:space="preserve"><value>Benchmark</value></data>
+  <data name="Menu_Crosshair" xml:space="preserve"><value>Mira Overlay</value></data>
+  <data name="Menu_Translator" xml:space="preserve"><value>Overlay de Traducción IA</value></data>
+  <data name="Menu_Notes" xml:space="preserve"><value>Notas Adhesivas</value></data>
+  <data name="Menu_Macro" xml:space="preserve"><value>Macro Experience</value></data>
+  <data name="Menu_WTF" xml:space="preserve"><value>WTF?!</value></data>
+  <data name="Menu_KbmStats" xml:space="preserve"><value>Estadísticas Teclado/Mouse</value></data>
+  <data name="Menu_Experience" xml:space="preserve"><value>Experiencia</value></data>
+  <data name="Menu_Settings" xml:space="preserve"><value>Configuración</value></data>
+  <data name="Menu_Links" xml:space="preserve"><value>Enlaces</value></data>
+  <data name="Menu_Discord" xml:space="preserve"><value>Unirse a Discord</value></data>
+  <data name="Menu_GTD" xml:space="preserve"><value>Acerca de GTD</value></data>
+  <data name="Menu_Support" xml:space="preserve"><value>Soporte</value></data>
+  <data name="Menu_Help" xml:space="preserve"><value>Ayuda</value></data>
+  <data name="Menu_About" xml:space="preserve"><value>Acerca de</value></data>
+  <data name="Home_Tagline" xml:space="preserve"><value>Tu centro gamer para overlays, automatizaciones e integraciones.</value></data>
+  <data name="Home_SelectFeature" xml:space="preserve"><value>Selecciona una función en el menú de arriba para comenzar.</value></data>
+  <data name="Update_Button" xml:space="preserve"><value>Actualizar</value></data>
+  <data name="Settings_Title" xml:space="preserve"><value>Comportamiento del GTD Companion</value></data>
+  <data name="Settings_AppBehavior" xml:space="preserve"><value>Comportamiento de la Aplicación</value></data>
+  <data name="Settings_StartMinimized" xml:space="preserve"><value>Iniciar minimizado con Windows</value></data>
+  <data name="Settings_Language" xml:space="preserve"><value>Idioma</value></data>
+  <data name="About_Title" xml:space="preserve"><value>Acerca del GTD Companion</value></data>
+  <data name="Translator_OpenOverlay" xml:space="preserve"><value>Abrir Overlay de Traducción</value></data>
+</root>

--- a/Resources/Resources.it-IT.resx
+++ b/Resources/Resources.it-IT.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Menu_Home" xml:space="preserve"><value>Inizio</value></data>
+  <data name="Menu_Features" xml:space="preserve"><value>Funzionalità</value></data>
+  <data name="Menu_MySetup" xml:space="preserve"><value>Il Mio Setup</value></data>
+  <data name="Menu_Benchmark" xml:space="preserve"><value>Benchmark</value></data>
+  <data name="Menu_Crosshair" xml:space="preserve"><value>Overlay Mirino</value></data>
+  <data name="Menu_Translator" xml:space="preserve"><value>Overlay Traduzione IA</value></data>
+  <data name="Menu_Notes" xml:space="preserve"><value>Note Adesive</value></data>
+  <data name="Menu_Macro" xml:space="preserve"><value>Macro Experience</value></data>
+  <data name="Menu_WTF" xml:space="preserve"><value>WTF?!</value></data>
+  <data name="Menu_KbmStats" xml:space="preserve"><value>Statistiche Tastiera/Mouse</value></data>
+  <data name="Menu_Experience" xml:space="preserve"><value>Esperienza</value></data>
+  <data name="Menu_Settings" xml:space="preserve"><value>Impostazioni</value></data>
+  <data name="Menu_Links" xml:space="preserve"><value>Link</value></data>
+  <data name="Menu_Discord" xml:space="preserve"><value>Entra su Discord</value></data>
+  <data name="Menu_GTD" xml:space="preserve"><value>Info su GTD</value></data>
+  <data name="Menu_Support" xml:space="preserve"><value>Supporto</value></data>
+  <data name="Menu_Help" xml:space="preserve"><value>Aiuto</value></data>
+  <data name="Menu_About" xml:space="preserve"><value>Informazioni</value></data>
+  <data name="Home_Tagline" xml:space="preserve"><value>Il tuo hub gamer per overlay, automazioni e integrazioni.</value></data>
+  <data name="Home_SelectFeature" xml:space="preserve"><value>Seleziona una funzione dal menu sopra per iniziare.</value></data>
+  <data name="Update_Button" xml:space="preserve"><value>Aggiorna</value></data>
+  <data name="Settings_Title" xml:space="preserve"><value>Comportamento di GTD Companion</value></data>
+  <data name="Settings_AppBehavior" xml:space="preserve"><value>Comportamento dell'Applicazione</value></data>
+  <data name="Settings_StartMinimized" xml:space="preserve"><value>Avvia minimizzato con Windows</value></data>
+  <data name="Settings_Language" xml:space="preserve"><value>Lingua</value></data>
+  <data name="About_Title" xml:space="preserve"><value>Informazioni su GTD Companion</value></data>
+  <data name="Translator_OpenOverlay" xml:space="preserve"><value>Apri Overlay di Traduzione</value></data>
+</root>

--- a/Resources/Resources.resx
+++ b/Resources/Resources.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Menu_Home" xml:space="preserve">
+    <value>Início</value>
+  </data>
+  <data name="Menu_Features" xml:space="preserve">
+    <value>Funcionalidades</value>
+  </data>
+  <data name="Menu_MySetup" xml:space="preserve">
+    <value>Meu Setup</value>
+  </data>
+  <data name="Menu_Benchmark" xml:space="preserve">
+    <value>Benchmark</value>
+  </data>
+  <data name="Menu_Crosshair" xml:space="preserve">
+    <value>Mira Overlay</value>
+  </data>
+  <data name="Menu_Translator" xml:space="preserve">
+    <value>Tradução IA Overlay</value>
+  </data>
+  <data name="Menu_Notes" xml:space="preserve">
+    <value>Sticker Notes</value>
+  </data>
+  <data name="Menu_Macro" xml:space="preserve">
+    <value>Macro Experience</value>
+  </data>
+  <data name="Menu_WTF" xml:space="preserve">
+    <value>WTF?!</value>
+  </data>
+  <data name="Menu_KbmStats" xml:space="preserve">
+    <value>Estatísticas Teclado/Mouse</value>
+  </data>
+  <data name="Menu_Experience" xml:space="preserve">
+    <value>Experiência</value>
+  </data>
+  <data name="Menu_Settings" xml:space="preserve">
+    <value>Configurações</value>
+  </data>
+  <data name="Menu_Links" xml:space="preserve">
+    <value>Links</value>
+  </data>
+  <data name="Menu_Discord" xml:space="preserve">
+    <value>Acessar Discord</value>
+  </data>
+  <data name="Menu_GTD" xml:space="preserve">
+    <value>A GTD</value>
+  </data>
+  <data name="Menu_Support" xml:space="preserve">
+    <value>Suporte</value>
+  </data>
+  <data name="Menu_Help" xml:space="preserve">
+    <value>Ajuda</value>
+  </data>
+  <data name="Menu_About" xml:space="preserve">
+    <value>Sobre</value>
+  </data>
+  <data name="Home_Tagline" xml:space="preserve">
+    <value>Sua central gamer para overlays, automações e integrações.</value>
+  </data>
+  <data name="Home_SelectFeature" xml:space="preserve">
+    <value>Selecione uma funcionalidade no menu acima para começar.</value>
+  </data>
+  <data name="Update_Button" xml:space="preserve">
+    <value>Atualizar</value>
+  </data>
+  <data name="Settings_Title" xml:space="preserve">
+    <value>Comportamento do GTD Companion</value>
+  </data>
+  <data name="Settings_AppBehavior" xml:space="preserve">
+    <value>Comportamento do Aplicativo</value>
+  </data>
+  <data name="Settings_StartMinimized" xml:space="preserve">
+    <value>Inicializar Minimizado com o Windows</value>
+  </data>
+  <data name="Settings_Language" xml:space="preserve">
+    <value>Idioma</value>
+  </data>
+  <data name="About_Title" xml:space="preserve">
+    <value>Sobre o GTD Companion</value>
+  </data>
+  <data name="Translator_OpenOverlay" xml:space="preserve">
+    <value>Abrir Overlay de Tradução</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- implement `LocalizationManager` with markup extension `Tr` to handle translations
- include resource files for Brazilian Portuguese (default), English, Spanish and Italian
- apply translations to Home page, About page, Settings and main menus
- allow language selection in Settings page and persist it

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684811e69044832aa8e0b2d8dc213032