### PR TITLE
Fix localization compile errors

### DIFF
--- a/GTDCompanion.csproj
+++ b/GTDCompanion.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Avalonia" Version="11.3.0" />
     <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.0" />
     <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Markup.Xaml" Version="11.3.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
     <PackageReference Include="CodingSeb.Localization.Avalonia" Version="1.4.1" />

--- a/Helpers/LocalizationManager.cs
+++ b/Helpers/LocalizationManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Reflection;
 using System.Resources;
+using Avalonia;
 using Avalonia.Data;
 using Avalonia.Markup.Xaml.MarkupExtensions;
 
@@ -50,7 +51,7 @@ namespace GTDCompanion.Helpers
             _default = def;
             LocalizationManager.LanguageChanged += OnChanged;
         }
-        public InstancedBinding? Initiate(Avalonia.AvaloniaObject target, Avalonia.AvaloniaProperty property, object? anchor, bool enableDataValidation)
+        public InstancedBinding? Initiate(AvaloniaObject target, AvaloniaProperty? targetProperty, object? anchor = null, bool enableDataValidation = false)
         {
             return InstancedBinding.OneWay(GetValue(), _ => { _valueChanged = _; });
         }


### PR DESCRIPTION
## Summary
- add missing Avalonia.Markup.Xaml package
- update LocalizationManager for Avalonia 11.3 API changes

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684815a92ab0832abf7b5241024f304f