### PR TITLE
Fix chat overlay list binding

### DIFF
--- a/Pages/Streamer/ChatOverlay.axaml.cs
+++ b/Pages/Streamer/ChatOverlay.axaml.cs
@@ -32,7 +32,7 @@ namespace GTDCompanion.Pages
         {
             _config = cfg;
             InitializeComponent();
-            MessagesList.Items = _messages;
+            MessagesList.ItemsSource = _messages;
             Opacity = cfg.OverlayOpacity;
             Height = 400;
             FontSize = cfg.FontSize;


### PR DESCRIPTION
## Summary
- fix ItemsControl usage by assigning the messages collection to `ItemsSource` rather than the read-only `Items` property

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ae59ab2c832a967e9d9cf66d9690