### PR TITLE
Fix Twitch chat overlay and real-time settings

### DIFF
--- a/Pages/Streamer/ChatOverlay.axaml.cs
+++ b/Pages/Streamer/ChatOverlay.axaml.cs
@@ -21,6 +21,15 @@ namespace GTDCompanion.Pages
         private readonly StreamerConfig _config;
         private readonly ObservableCollection<ChatMessage> _messages = new();
         private CancellationTokenSource? _cts;
+        
+        public void UpdateAppearance(double opacity, int fontSize)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                Opacity = opacity;
+                FontSize = fontSize;
+            });
+        }
         private bool dragging;
         private PixelPoint dragOffset;
         private bool _collapsed;
@@ -117,8 +126,28 @@ namespace GTDCompanion.Pages
             }
         }
 
+        private string NormalizeTwitchSlug(string slug)
+        {
+            slug = slug.Trim();
+            if (slug.Contains("twitch.tv", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    var uri = new Uri(slug);
+                    slug = uri.AbsolutePath.Trim('/');
+                }
+                catch { }
+            }
+            if (slug.StartsWith("@"))
+                slug = slug.Substring(1);
+            if (slug.StartsWith("#"))
+                slug = slug.Substring(1);
+            return slug;
+        }
+
         private async Task RunTwitchAsync(string slug, CancellationToken token)
         {
+            slug = NormalizeTwitchSlug(slug);
             if (string.IsNullOrWhiteSpace(slug))
             {
                 ConnectionFailed?.Invoke("Twitch");

--- a/Pages/Streamer/StreamerPage.axaml.cs
+++ b/Pages/Streamer/StreamerPage.axaml.cs
@@ -51,6 +51,7 @@ namespace GTDCompanion.Pages
                 FontSize = (int)FontSizeSlider.Value
             };
             GTDConfigHelper.SaveStreamerConfig(cfg);
+            _overlay?.UpdateAppearance(cfg.OverlayOpacity, cfg.FontSize);
         }
 
         private void OpenOverlayButton_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- normalize Twitch channel slug so URLs work
- allow overlay opacity and font size to update in real time
- expose a method on ChatOverlay to apply appearance updates

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848b10269a8832aa429be1db1aa74d9