### PR TITLE
Support simultaneous Twitch and YouTube chat

### DIFF
--- a/GTDConfigHelper.cs
+++ b/GTDConfigHelper.cs
@@ -22,7 +22,8 @@ namespace GTDCompanion
 
     public class StreamerConfig
     {
-        public string Platform { get; set; } = "YouTube";
+        public bool UseYouTube { get; set; } = true;
+        public bool UseTwitch { get; set; } = false;
         public string YoutubeLink { get; set; } = string.Empty;
         public string TwitchSlug { get; set; } = string.Empty;
         public double OverlayOpacity { get; set; } = 0.9;
@@ -167,19 +168,29 @@ namespace GTDCompanion
         // ---- Streamer Chat ----
         public static StreamerConfig LoadStreamerConfig()
         {
-            return new StreamerConfig
+            var cfg = new StreamerConfig
             {
-                Platform = GetString("Streamer", "Platform", "YouTube"),
+                UseYouTube = GetBool("Streamer", "UseYouTube", true),
+                UseTwitch = GetBool("Streamer", "UseTwitch", false),
                 YoutubeLink = GetString("Streamer", "YoutubeLink", string.Empty),
                 TwitchSlug = GetString("Streamer", "TwitchSlug", string.Empty),
                 OverlayOpacity = GetDouble("Streamer", "OverlayOpacity", 0.9),
                 FontSize = GetInt("Streamer", "FontSize", 12)
             };
+            // Backwards compatibility with old "Platform" field
+            string platform = GetString("Streamer", "Platform", string.Empty);
+            if (!string.IsNullOrWhiteSpace(platform))
+            {
+                cfg.UseTwitch = platform.Equals("Twitch", StringComparison.OrdinalIgnoreCase);
+                cfg.UseYouTube = platform.Equals("YouTube", StringComparison.OrdinalIgnoreCase);
+            }
+            return cfg;
         }
 
         public static void SaveStreamerConfig(StreamerConfig cfg)
         {
-            Set("Streamer", "Platform", cfg.Platform);
+            Set("Streamer", "UseYouTube", cfg.UseYouTube ? "1" : "0");
+            Set("Streamer", "UseTwitch", cfg.UseTwitch ? "1" : "0");
             Set("Streamer", "YoutubeLink", cfg.YoutubeLink);
             Set("Streamer", "TwitchSlug", cfg.TwitchSlug);
             Set("Streamer", "OverlayOpacity", cfg.OverlayOpacity.ToString(System.Globalization.CultureInfo.InvariantCulture));

--- a/Pages/Streamer/ChatOverlay.axaml
+++ b/Pages/Streamer/ChatOverlay.axaml
@@ -20,6 +20,7 @@
           <ItemsControl.ItemTemplate>
             <DataTemplate x:DataType="local:ChatMessage">
               <StackPanel Orientation="Horizontal" Margin="0,2">
+                <TextBlock Text="{Binding SourceIcon}" Margin="0,0,4,0" Foreground="White"/>
                 <TextBlock Text="{Binding User}" FontWeight="Bold" Margin="0,0,4,0" Foreground="White">
                   <TextBlock.Effect>
                     <DropShadowEffect Color="Gold" BlurRadius="10" Opacity="{Binding DonationShadow}"/>

--- a/Pages/Streamer/StreamerPage.axaml
+++ b/Pages/Streamer/StreamerPage.axaml
@@ -4,20 +4,19 @@
   <Border Background="#222" CornerRadius="12" Padding="20">
     <StackPanel Spacing="12" Width="420">
       <TextBlock Text="Leitor de Chat para Lives" FontSize="24" Foreground="#FE6A0A" FontWeight="Bold" HorizontalAlignment="Center"/>
-      <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-        <TextBlock Text="Plataforma:" Foreground="White" VerticalAlignment="Center"/>
-        <ComboBox Name="PlatformCombo" Width="120">
-          <ComboBoxItem Content="YouTube"/>
-          <ComboBoxItem Content="Twitch"/>
-        </ComboBox>
-      </StackPanel>
       <StackPanel Spacing="4">
-        <TextBlock Name="YoutubeLabel" Text="Link da Live do YouTube:" Foreground="White"/>
+        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+          <TextBlock Text="Link da Live do YouTube:" Foreground="White"/>
+          <CheckBox Name="UseYoutubeCheck" Content="Ativar"/>
+        </StackPanel>
         <TextBox Name="YoutubeLinkBox"/>
         <TextBlock Name="YoutubeError" Foreground="Red" FontSize="12"/>
       </StackPanel>
       <StackPanel Spacing="4">
-        <TextBlock Name="TwitchLabel" Text="Slug do canal Twitch:" Foreground="White"/>
+        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+          <TextBlock Text="Slug do canal Twitch:" Foreground="White"/>
+          <CheckBox Name="UseTwitchCheck" Content="Ativar"/>
+        </StackPanel>
         <TextBox Name="TwitchSlugBox"/>
         <TextBlock Name="TwitchError" Foreground="Red" FontSize="12"/>
       </StackPanel>

--- a/Pages/Streamer/StreamerPage.axaml.cs
+++ b/Pages/Streamer/StreamerPage.axaml.cs
@@ -1,7 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using System;
-using System.Threading;
 
 namespace GTDCompanion.Pages
 {
@@ -13,14 +12,17 @@ namespace GTDCompanion.Pages
         {
             InitializeComponent();
             var cfg = GTDConfigHelper.LoadStreamerConfig();
-            PlatformCombo.SelectedIndex = cfg.Platform.Equals("Twitch", StringComparison.OrdinalIgnoreCase) ? 1 : 0;
+            UseYoutubeCheck.IsChecked = cfg.UseYouTube;
+            UseTwitchCheck.IsChecked = cfg.UseTwitch;
             YoutubeLinkBox.Text = cfg.YoutubeLink;
             TwitchSlugBox.Text = cfg.TwitchSlug;
             OpacitySlider.Value = cfg.OverlayOpacity;
             FontSizeSlider.Value = cfg.FontSize;
-            UpdateVisibility();
 
-            PlatformCombo.SelectionChanged += (_, __) => { Save(); UpdateVisibility(); };
+            UseYoutubeCheck.Checked += (_, __) => Save();
+            UseYoutubeCheck.Unchecked += (_, __) => Save();
+            UseTwitchCheck.Checked += (_, __) => Save();
+            UseTwitchCheck.Unchecked += (_, __) => Save();
             YoutubeLinkBox.PropertyChanged += (_, e) => { if (e.Property.Name == "Text") Save(); };
             TwitchSlugBox.PropertyChanged += (_, e) => { if (e.Property.Name == "Text") Save(); };
             OpacitySlider.PropertyChanged += (_, e) => { if (e.Property.Name == "Value") Save(); };
@@ -29,22 +31,12 @@ namespace GTDCompanion.Pages
             OpenOverlayButton.Click += OpenOverlayButton_Click;
         }
 
-        private void UpdateVisibility()
-        {
-            bool twitch = PlatformCombo.SelectedIndex == 1;
-            YoutubeLabel.IsVisible = !twitch;
-            YoutubeLinkBox.IsVisible = !twitch;
-            YoutubeError.IsVisible = false;
-            TwitchLabel.IsVisible = twitch;
-            TwitchSlugBox.IsVisible = twitch;
-            TwitchError.IsVisible = false;
-        }
-
         private void Save()
         {
             var cfg = new StreamerConfig
             {
-                Platform = PlatformCombo.SelectedIndex == 1 ? "Twitch" : "YouTube",
+                UseYouTube = UseYoutubeCheck.IsChecked ?? false,
+                UseTwitch = UseTwitchCheck.IsChecked ?? false,
                 YoutubeLink = YoutubeLinkBox.Text ?? string.Empty,
                 TwitchSlug = TwitchSlugBox.Text ?? string.Empty,
                 OverlayOpacity = OpacitySlider.Value,


### PR DESCRIPTION
## Summary
- extend `StreamerConfig` to store YouTube and Twitch settings separately
- show both chat options with activation checkboxes
- allow ChatOverlay to connect to Twitch and YouTube at the same time
- prepend an icon identifying chat source in overlay

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b3277ff0832a8e5db217c9214a86