### PR TITLE
Fix missing generated fields in Streamer UI

### DIFF
--- a/Pages/Streamer/ChatOverlay.axaml
+++ b/Pages/Streamer/ChatOverlay.axaml
@@ -11,12 +11,12 @@
         Topmost="True">
   <Border CornerRadius="14" Background="#DD23272A" Padding="14,0,14,14">
     <StackPanel>
-      <DockPanel Name="CustomTitleBar" Height="30">
+      <DockPanel x:Name="CustomTitleBar" Height="30">
         <TextBlock Text="Chat Overlay" Foreground="#FF9800" FontSize="14" Margin="16,0,0,0" DockPanel.Dock="Left"/>
-        <Button Name="CloseButton" Content="X" Width="28" Height="28" Margin="0,0,8,0" DockPanel.Dock="Right"/>
+        <Button x:Name="CloseButton" Content="X" Width="28" Height="28" Margin="0,0,8,0" DockPanel.Dock="Right"/>
       </DockPanel>
-      <ScrollViewer Name="Scroll" Height="330">
-        <ItemsControl Name="MessagesList">
+      <ScrollViewer x:Name="Scroll" Height="330">
+        <ItemsControl x:Name="MessagesList">
           <ItemsControl.ItemTemplate>
             <DataTemplate x:DataType="local:ChatMessage">
               <StackPanel Orientation="Horizontal" Margin="0,2">

--- a/Pages/Streamer/StreamerPage.axaml
+++ b/Pages/Streamer/StreamerPage.axaml
@@ -7,30 +7,30 @@
       <StackPanel Spacing="4">
         <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
           <TextBlock Text="Link da Live do YouTube:" Foreground="White"/>
-          <CheckBox Name="UseYoutubeCheck" Content="Ativar"/>
+          <CheckBox x:Name="UseYoutubeCheck" Content="Ativar"/>
         </StackPanel>
-        <TextBox Name="YoutubeLinkBox"/>
-        <TextBlock Name="YoutubeError" Foreground="Red" FontSize="12"/>
+        <TextBox x:Name="YoutubeLinkBox"/>
+        <TextBlock x:Name="YoutubeError" Foreground="Red" FontSize="12"/>
       </StackPanel>
       <StackPanel Spacing="4">
         <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
           <TextBlock Text="Slug do canal Twitch:" Foreground="White"/>
-          <CheckBox Name="UseTwitchCheck" Content="Ativar"/>
+          <CheckBox x:Name="UseTwitchCheck" Content="Ativar"/>
         </StackPanel>
-        <TextBox Name="TwitchSlugBox"/>
-        <TextBlock Name="TwitchError" Foreground="Red" FontSize="12"/>
+        <TextBox x:Name="TwitchSlugBox"/>
+        <TextBlock x:Name="TwitchError" Foreground="Red" FontSize="12"/>
       </StackPanel>
       <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
         <StackPanel Width="150">
           <TextBlock Text="Transparência:" Foreground="White"/>
-          <Slider Name="OpacitySlider" Minimum="0.3" Maximum="1" Value="0.9"/>
+          <Slider x:Name="OpacitySlider" Minimum="0.3" Maximum="1" Value="0.9"/>
         </StackPanel>
         <StackPanel Width="150">
           <TextBlock Text="Tamanho Fonte:" Foreground="White"/>
-          <Slider Name="FontSizeSlider" Minimum="8" Maximum="20" Value="12"/>
+          <Slider x:Name="FontSizeSlider" Minimum="8" Maximum="20" Value="12"/>
         </StackPanel>
       </StackPanel>
-      <Button Name="OpenOverlayButton" Content="Abrir Overlay" Width="160" HorizontalAlignment="Center"/>
+      <Button x:Name="OpenOverlayButton" Content="Abrir Overlay" Width="160" HorizontalAlignment="Center"/>
     </StackPanel>
   </Border>
 </UserControl>


### PR DESCRIPTION
## Summary
- use `x:Name` in chat overlay and streamer page XAML so code-behind can access controls

## Testing
- `dotnet build -nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848b4b82c28832aa67c94763bba940d