### PR TITLE
Implement startup tweak and note copy button

### DIFF
--- a/Pages/Experience/SettingsPage.axaml
+++ b/Pages/Experience/SettingsPage.axaml
@@ -7,7 +7,7 @@
             <TextBlock Text="Comportamento do GTD Companion" FontSize="24" Foreground="#FE6A0A" FontWeight="Bold"/>
             <StackPanel>
                 <TextBlock Text="Comportamento do Aplicativo" FontSize="18" Foreground="White" Margin="0,8,0,4"/>
-                <CheckBox x:Name="StartMinimizedBox" Content="Inicializar Minimizado com o Windows" IsChecked="True"/>
+                <CheckBox x:Name="StartMinimizedBox" Content="Inicializar com o Windows" IsChecked="True"/>
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/Pages/Experience/SettingsPage.axaml.cs
+++ b/Pages/Experience/SettingsPage.axaml.cs
@@ -39,7 +39,7 @@ namespace GTDCompanion.Pages
             if (isChecked)
             {
                 var exePath = Process.GetCurrentProcess().MainModule?.FileName ?? string.Empty;
-                key.SetValue("GTDCompanion", $"\"{exePath}\" minimized");
+                key.SetValue("GTDCompanion", $"\"{exePath}\"");
             }
             else
             {

--- a/Pages/StickerNotes/StickerNoteWindow.axaml
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml
@@ -12,6 +12,7 @@
     <StackPanel Spacing="6">
       <DockPanel Name="CustomTitleBar" Height="30" HorizontalAlignment="Stretch" PointerPressed="CustomTitleBar_PointerPressed">
         <TextBlock Text="Sticker Note" Foreground="#FF9800" FontSize="14" Margin="8,0,0,0" VerticalAlignment="Center" DockPanel.Dock="Left"/>
+        <Button Name="CopyButton" Content="⧉" Width="24" Height="24" Margin="0,0,4,0" Background="#333" Foreground="White" HorizontalAlignment="Right" DockPanel.Dock="Right"/>
       </DockPanel>
       <TextBox Name="NoteTextBox" AcceptsReturn="True" TextWrapping="Wrap" Height="100" Background="#333" Foreground="White"/>
       <Slider Name="TransparencySlider" Minimum="0.3" Maximum="1" Value="0.9"/>

--- a/Pages/StickerNotes/StickerNoteWindow.axaml.cs
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml.cs
@@ -22,6 +22,11 @@ namespace GTDCompanion.Pages
             this.index = index;
             InitializeComponent();
 
+            if (this.FindControl<Button>("CopyButton") is Button copyBtn)
+            {
+                copyBtn.Click += CopyButton_Click;
+            }
+
             lineHeight = NoteTextBox.Height / 4;
             windowOffset = Height - NoteTextBox.Height;
 
@@ -100,6 +105,12 @@ namespace GTDCompanion.Pages
                 var screenPos = this.PointToScreen(e.GetPosition(this));
                 Position = new PixelPoint(screenPos.X - dragOffset.X, screenPos.Y - dragOffset.Y);
             }
+        }
+
+        private async void CopyButton_Click(object? sender, RoutedEventArgs e)
+        {
+            if (this.Clipboard != null)
+                await this.Clipboard.SetTextAsync(NoteTextBox.Text ?? string.Empty);
         }
 
         private void UpdateWindowTitle(string text)


### PR DESCRIPTION
## Summary
- adjust Settings to only enable normal startup
- allow copying sticker note text from title bar

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c24670308832ab73601697fe99ab7