### PR TITLE
Improve sticker notes features

### DIFF
--- a/Helpers/StickerNoteStorage.cs
+++ b/Helpers/StickerNoteStorage.cs
@@ -6,24 +6,57 @@ namespace GTDCompanion.Helpers
 {
     public static class StickerNoteStorage
     {
+        private const int NoteCount = 10;
         private static readonly string DataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GTDCompanion");
+        private static readonly string NotesPath = Path.Combine(DataDir, "notes.json");
+
+        private static StickerNoteData[] LoadAll()
+        {
+            if (!File.Exists(NotesPath))
+                return CreateDefaultArray();
+
+            try
+            {
+                var json = File.ReadAllText(NotesPath);
+                var arr = JsonSerializer.Deserialize<StickerNoteData[]>(json);
+                if (arr != null && arr.Length == NoteCount)
+                    return arr;
+            }
+            catch { }
+
+            return CreateDefaultArray();
+        }
+
+        private static void SaveAll(StickerNoteData[] data)
+        {
+            if (!Directory.Exists(DataDir))
+                Directory.CreateDirectory(DataDir);
+
+            var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(NotesPath, json);
+        }
+
+        private static StickerNoteData[] CreateDefaultArray()
+        {
+            var arr = new StickerNoteData[NoteCount];
+            for (int i = 0; i < NoteCount; i++)
+                arr[i] = new StickerNoteData();
+            return arr;
+        }
 
         public static StickerNoteData Load(int index)
         {
-            var path = Path.Combine(DataDir, $"note{index}.json");
-            if (!File.Exists(path))
-                return new StickerNoteData();
-            var json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize<StickerNoteData>(json) ?? new StickerNoteData();
+            var all = LoadAll();
+            if (index < 1 || index > NoteCount) return new StickerNoteData();
+            return all[index - 1];
         }
 
         public static void Save(int index, StickerNoteData data)
         {
-            if (!Directory.Exists(DataDir))
-                Directory.CreateDirectory(DataDir);
-            var path = Path.Combine(DataDir, $"note{index}.json");
-            var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(path, json);
+            if (index < 1 || index > NoteCount) return;
+            var all = LoadAll();
+            all[index - 1] = data;
+            SaveAll(all);
         }
     }
 
@@ -33,5 +66,6 @@ namespace GTDCompanion.Helpers
         public double Opacity { get; set; } = 0.9;
         public int PosX { get; set; } = -1;
         public int PosY { get; set; } = -1;
+        public string Title { get; set; } = string.Empty;
     }
 }

--- a/Pages/StickerNotes/NoteNameDialog.axaml
+++ b/Pages/StickerNotes/NoteNameDialog.axaml
@@ -1,0 +1,18 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="GTDCompanion.Pages.NoteNameDialog"
+        Width="300" Height="150"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Background="#282828"
+        Topmost="True">
+  <StackPanel Margin="20" Spacing="10" HorizontalAlignment="Center">
+    <TextBlock Text="Nome da nota:" Foreground="White"/>
+    <TextBox Name="NameTextBox" Width="200"/>
+    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+      <Button Name="ClearButton" Content="Limpar Nota" Width="90"/>
+      <Button Name="OkButton" Content="OK" Width="60"/>
+      <Button Name="CancelButton" Content="Cancelar" Width="80"/>
+    </StackPanel>
+  </StackPanel>
+</Window>

--- a/Pages/StickerNotes/NoteNameDialog.axaml.cs
+++ b/Pages/StickerNotes/NoteNameDialog.axaml.cs
@@ -1,0 +1,32 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace GTDCompanion.Pages
+{
+    public partial class NoteNameDialog : Window
+    {
+        public string? ResultName { get; private set; }
+        public bool IsCleared { get; private set; }
+
+        public NoteNameDialog(string currentName)
+        {
+            InitializeComponent();
+            NameTextBox.Text = currentName;
+            OkButton.Click += OkButton_Click;
+            CancelButton.Click += (_, __) => Close();
+            ClearButton.Click += ClearButton_Click;
+        }
+
+        private void OkButton_Click(object? sender, RoutedEventArgs e)
+        {
+            ResultName = NameTextBox.Text;
+            Close();
+        }
+
+        private void ClearButton_Click(object? sender, RoutedEventArgs e)
+        {
+            IsCleared = true;
+            Close();
+        }
+    }
+}

--- a/Pages/StickerNotes/StickerNoteWindow.axaml
+++ b/Pages/StickerNotes/StickerNoteWindow.axaml
@@ -11,8 +11,11 @@
   <Border CornerRadius="12" Background="#DD23272A" Padding="10,7,10,10">
     <StackPanel Spacing="6">
       <DockPanel Margin="0,0,0,5"  VerticalAlignment="Center" Name="CustomTitleBar" Height="30" HorizontalAlignment="Stretch" PointerPressed="CustomTitleBar_PointerPressed">
-        <TextBlock Text="Sticker Note" Foreground="#FF9800" FontSize="14" VerticalAlignment="Center" DockPanel.Dock="Left"/>
-        <Button Name="CopyButton" Content="⧉" Background="#333" Foreground="White" HorizontalAlignment="Right" DockPanel.Dock="Right"/>
+        <TextBlock Name="TitleText" Text="Sticker Note" Foreground="#FF9800" FontSize="14" VerticalAlignment="Center" DockPanel.Dock="Left"/>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Right">
+          <Button Name="CloseButton" Content="X" Background="#600" Foreground="White" Margin="0,0,4,0"/>
+          <Button Name="CopyButton" Content="⧉" Background="#333" Foreground="White"/>
+        </StackPanel>
       </DockPanel>
       <TextBox Name="NoteTextBox" AcceptsReturn="True" TextWrapping="Wrap" Height="100" Background="#333" Foreground="White"/>
       <Slider Name="TransparencySlider" Minimum="0.3" Maximum="1" Value="0.9"/>

--- a/Pages/StickerNotes/StickerNotesPage.axaml
+++ b/Pages/StickerNotes/StickerNotesPage.axaml
@@ -7,13 +7,32 @@
         <TextBlock Text="Sticker Notes Overlay" FontSize="24" Foreground="#FE6A0A" FontWeight="Bold" HorizontalAlignment="Center"/>
       </StackPanel>
       <TextBlock Text="Crie notas rápidas que ficam sobre todas as janelas." Foreground="#CCC" HorizontalAlignment="Center"/>
-      <WrapPanel HorizontalAlignment="Center">
-        <Button Name="Note1Button" Content="Nota 1" Width="80" Height="30" Margin="4"/>
-        <Button Name="Note2Button" Content="Nota 2" Width="80" Height="30" Margin="4"/>
-        <Button Name="Note3Button" Content="Nota 3" Width="80" Height="30" Margin="4"/>
-        <Button Name="Note4Button" Content="Nota 4" Width="80" Height="30" Margin="4"/>
-        <Button Name="Note5Button" Content="Nota 5" Width="80" Height="30" Margin="4"/>
-      </WrapPanel>
+      <Grid HorizontalAlignment="Center" ColumnDefinitions="Auto,Auto,Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+        <Button Name="Note1Button" Content="Nota 1" Width="90" Height="30" Margin="4" Grid.Row="0" Grid.Column="0"/>
+        <Button Name="Config1Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="0" Grid.Column="1"/>
+        <Button Name="Note6Button" Content="Nota 6" Width="90" Height="30" Margin="4" Grid.Row="0" Grid.Column="2"/>
+        <Button Name="Config6Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="0" Grid.Column="3"/>
+
+        <Button Name="Note2Button" Content="Nota 2" Width="90" Height="30" Margin="4" Grid.Row="1" Grid.Column="0"/>
+        <Button Name="Config2Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="1" Grid.Column="1"/>
+        <Button Name="Note7Button" Content="Nota 7" Width="90" Height="30" Margin="4" Grid.Row="1" Grid.Column="2"/>
+        <Button Name="Config7Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="1" Grid.Column="3"/>
+
+        <Button Name="Note3Button" Content="Nota 3" Width="90" Height="30" Margin="4" Grid.Row="2" Grid.Column="0"/>
+        <Button Name="Config3Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="2" Grid.Column="1"/>
+        <Button Name="Note8Button" Content="Nota 8" Width="90" Height="30" Margin="4" Grid.Row="2" Grid.Column="2"/>
+        <Button Name="Config8Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="2" Grid.Column="3"/>
+
+        <Button Name="Note4Button" Content="Nota 4" Width="90" Height="30" Margin="4" Grid.Row="3" Grid.Column="0"/>
+        <Button Name="Config4Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="3" Grid.Column="1"/>
+        <Button Name="Note9Button" Content="Nota 9" Width="90" Height="30" Margin="4" Grid.Row="3" Grid.Column="2"/>
+        <Button Name="Config9Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="3" Grid.Column="3"/>
+
+        <Button Name="Note5Button" Content="Nota 5" Width="90" Height="30" Margin="4" Grid.Row="4" Grid.Column="0"/>
+        <Button Name="Config5Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="4" Grid.Column="1"/>
+        <Button Name="Note10Button" Content="Nota 10" Width="90" Height="30" Margin="4" Grid.Row="4" Grid.Column="2"/>
+        <Button Name="Config10Button" Content="⚙" Width="30" Height="30" Margin="4" Grid.Row="4" Grid.Column="3"/>
+      </Grid>
     </StackPanel>
   </Border>
 </UserControl>


### PR DESCRIPTION
## Summary
- store all sticker notes in a single `notes.json` with room for 10 entries
- allow each note to have a custom title
- add dialog to configure note titles and clear notes
- show 10 notes in two columns with config gears
- include close button on overlay window

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c453b3560832ab02bb1ca7349fee7