### PR TITLE
Fix missing StickerNoteConfig compilation error

### DIFF
--- a/Pages/StickerNotes/StickerNoteConfig.cs
+++ b/Pages/StickerNotes/StickerNoteConfig.cs
@@ -1,0 +1,10 @@
+namespace GTDCompanion
+{
+    public struct StickerNoteConfig
+    {
+        public string Text;
+        public double Opacity;
+        public int PosX;
+        public int PosY;
+    }
+}


### PR DESCRIPTION
## Summary
- add a StickerNoteConfig struct so GTDConfigHelper compiles

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c46fe3290832a89c05889eafef5f4