### PR TITLE
Fix missing namespace on StickerNotesPage

### DIFF
--- a/Pages/StickerNotes/StickerNotesPage.axaml.cs
+++ b/Pages/StickerNotes/StickerNotesPage.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using System.Threading.Tasks;
+using GTDCompanion.Helpers;
 
 namespace GTDCompanion.Pages
 {


### PR DESCRIPTION
## Summary
- add namespace import for `StickerNoteStorage`

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c47c38fdc832aa9fe236469325ed7